### PR TITLE
feat: pre-built self-contained binary via go:embed + GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,63 @@
+name: build
+
+# Builds a self-contained Linux/amd64 binary (assets embedded via go:embed)
+# and publishes it as a workflow artifact. The production server pulls this
+# artifact with scripts/deploy.sh — no Go toolchain needed on the server.
+#
+# Runs on every push to PyMouse (main) and on all pull requests so merges are
+# validated before they ship. To deploy a specific run, see scripts/deploy.sh.
+
+on:
+  push:
+    branches: [PyMouse]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build linux/amd64
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+            go build -trimpath -ldflags="-s -w" -o pymouse .
+
+      - name: Smoke-test the binary
+        run: |
+          # A self-contained binary must be able to resolve its embedded assets
+          # even when the source tree is not present on disk. Run it from an
+          # empty CWD; the process just needs to start without panicking on a
+          # missing .env (it will, and that's fine — we only want to confirm
+          # the binary is valid and linked).
+          file ./pymouse
+          test -x ./pymouse
+
+      - name: Upload artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pymouse-linux-amd64
+          path: pymouse
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,17 @@
 name: build
 
-# Builds a self-contained Linux/amd64 binary (assets embedded via go:embed)
-# and publishes it as a workflow artifact. The production server pulls this
-# artifact with scripts/deploy.sh — no Go toolchain needed on the server.
+# Builds a self-contained Linux/amd64 binary (assets embedded via go:embed) and
+# publishes it so the production server can pull a ready-to-run executable with
+# scripts/deploy.sh — no Go toolchain needed on the server.
 #
-# Runs on every push to PyMouse (main) and on all pull requests so merges are
-# validated before they ship. To deploy a specific run, see scripts/deploy.sh.
+#   - Pull requests:  binary published as a workflow artifact (for pre-merge
+#                     testing via `deploy.sh pr`). Expires in 30 days.
+#   - Push to PyMouse: binary published as a PERMANENT GitHub Release named
+#                     "<date>-<short-sha>" (e.g. 2026-08-04-1cc4e4d). Releases
+#                     do not expire, so you can roll back to any past version.
+#
+# `concurrency` cancels superseded runs on the same ref so only the latest
+# commit on each branch/PR produces a shippable binary.
 
 on:
   push:
@@ -13,7 +19,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: write   # required by softprops/action-gh-release to create releases
 
 concurrency:
   group: build-${{ github.ref }}
@@ -43,21 +49,47 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
             go build -trimpath -ldflags="-s -w" -o pymouse .
 
-      - name: Smoke-test the binary
+      - name: Verify binary
         run: |
-          # A self-contained binary must be able to resolve its embedded assets
-          # even when the source tree is not present on disk. Run it from an
-          # empty CWD; the process just needs to start without panicking on a
-          # missing .env (it will, and that's fine — we only want to confirm
-          # the binary is valid and linked).
           file ./pymouse
           test -x ./pymouse
+          ./pymouse -h >/dev/null 2>&1 || true   # don't fail on the bot's own arg handling
 
-      - name: Upload artifact
-        if: github.event_name == 'push'
+      - name: Compute release metadata
+        id: meta
+        run: |
+          echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      # ---- PR path: publish a temporary artifact --------------------------
+      - name: Upload artifact (PR builds)
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: pymouse-linux-amd64
           path: pymouse
           if-no-files-found: error
           retention-days: 30
+
+      # ---- Main path: publish a PERMANENT release -------------------------
+      # Tag + release name use "<YYYY-MM-DD>-<short-sha>", unique per commit,
+      # so every push to PyMouse is a distinct, rollback-able version.
+      - name: Create release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/PyMouse'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.run_id }}-${{ github.sha }}
+          name: ${{ format('{0}-{1}', env.RELEASE_DATE, env.SHORT_SHA) }}
+          body: |
+            Automated build of commit ${{ github.sha }} on PyMouse.
+
+            Commit: ${{ github.event.head_commit.message }}
+            Built: ${{ env.RELEASE_DATE }}
+            Source: ${{ github.event.head_commit.url }}
+
+            Install with: `scripts/deploy.sh ${{ format('{0}-{1}', env.RELEASE_DATE, env.SHORT_SHA) }}`
+          files: pymouse
+          make_latest: true
+        env:
+          RELEASE_DATE: ${{ steps.meta.outputs.date }}
+          SHORT_SHA: ${{ steps.meta.outputs.short }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 pymouse/downloads
 *.log
 youtubeCookies.txt
+
+# compiled binary (local builds + server deploy target)
+/bin/
+/dist/

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,24 +1,23 @@
 # Deploy
 
 The bot ships as a single pre-built binary. Assets (fonts, icons, locales) are
-embedded into the executable via `go:embed`, so the server does **not** need the
-`pymouse/assets/` or `locales/` trees on disk — only the binary, the `.env`
-file, and a writable directory for downloads.
+embedded into the executable via `go:embed`, so the server needs only the
+binary, the `.env` file, and a writable directory for downloads — **not** the
+`pymouse/assets/` or `locales/` trees.
 
-The repo checkout is still kept on the server as a fallback (so you can `go run`
-in an emergency) and because the bot reads `.env`, `youtubeCookies.txt`, and
-writes to `pymouse/downloads/` relative to its working directory.
+The repo checkout is still kept on the server as a fallback (so you can `go
+run` in an emergency) and because the bot reads `.env`, `youtubeCookies.txt`,
+and writes to `pymouse/downloads/` relative to its working directory.
 
-## Pipeline
+## How binaries are published
 
-1. Push to `PyMouse` (or merge a PR) → `.github/workflows/build.yml` builds a
-   `linux/amd64` binary with `CGO_ENABLED=0` and publishes it as the artifact
-   `pymouse-linux-amd64`.
-2. On the server, `scripts/deploy.sh` downloads the latest successful artifact,
-   installs it to `/root/PyMouse/bin/pymouse`, and restarts the service.
+| Trigger | What gets published | Lifetime |
+|---|---|---|
+| **Pull request** (any branch) | Workflow artifact `pymouse-linux-amd64` | 30 days |
+| **Push to `PyMouse`** (main) | **GitHub Release**, tagged `<YYYY-MM-DD>-<short-sha>` (e.g. `2026-08-04-1cc4e4d`), marked `latest` | **Permanent** |
 
-Deploy is manual on purpose — merging a PR does **not** automatically update
-production. Run `scripts/deploy.sh` when you are ready.
+Releases do not expire, so every push to main is a distinct, rollback-able
+version. PR artifacts are for pre-merge testing only.
 
 ## One-time server setup
 
@@ -52,38 +51,56 @@ systemctl enable pymouse
 Key changes vs. the old unit:
 - `ExecStart` runs the pre-built binary instead of `go run`.
 - The `ExecStartPre=go clean -cache -modcache -i -r` line is **removed** —
-  there is nothing to compile at startup anymore, so restarts are instant.
+  there is nothing to compile at startup, so restarts are instant.
 - `EnvironmentFile` points at `.env` (the old unit pointed at `PyMouse.log`,
   which was incorrect).
 
 ### 2. GitHub CLI
 
-`scripts/deploy.sh` uses `gh` to download artifacts. Authenticate once:
+`scripts/deploy.sh` uses `gh` to download binaries. Authenticate once:
 
 ```bash
 gh auth login
 ```
 
-Choose GitHub.com → HTTPS, and paste a personal access token with `read`
-access to `BubbalooTeam/PyMouse` (workflow `contents: read` + `actions: read`).
+Choose GitHub.com → HTTPS, and authenticate with access to
+`BubbalooTeam/PyMouse`.
 
 ## Deploying
 
+`scripts/deploy.sh` auto-detects what to install based on its argument:
+
+| Command | Installs |
+|---|---|
+| `scripts/deploy.sh` | latest release on PyMouse (the production default) |
+| `scripts/deploy.sh pr` | artifact from the latest successful PR build (pre-merge test) |
+| `scripts/deploy.sh <run-id>` | a specific PR workflow run (numeric) |
+| `scripts/deploy.sh <tag>` | a specific release tag, e.g. `2026-08-04-1cc4e4d` |
+
+Typical flows:
+
 ```bash
-cd /root/PyMouse
-git pull                              # keep the checkout in sync (for .env, fallback)
-scripts/deploy.sh                     # pull the latest build + restart
+# Production update after merging a PR:
+cd /root/PyMouse && git pull && scripts/deploy.sh
+
+# Test a PR before merging:
+scripts/deploy.sh pr
+
+# Roll back to a known-good version:
+scripts/deploy.sh 2026-08-04-1cc4e4d
 ```
 
-To deploy a specific workflow run: `scripts/deploy.sh <run-id>`.
+`scripts/deploy.sh` always restarts the `pymouse` service and tails the last
+20 journal lines.
 
 ## Rollback / fallback
 
-If the new binary misbehaves, you have two options:
+If a new binary misbehaves:
 
-- **Previous binary**: re-run `scripts/deploy.sh <older-run-id>`.
-- **`go run` fallback** (the old way): temporarily point the unit back at
-  `go run` — the repo checkout is still on disk.
+- **Previous version**: `scripts/deploy.sh <older-tag>` — releases are
+  permanent, so any past main build is still available.
+- **`go run` fallback** (the original method): the repo checkout is still on
+  disk. Temporarily point the unit back at `go run`:
 
   ```bash
   # edit /etc/systemd/system/pymouse.service ExecStart to:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,93 @@
+# Deploy
+
+The bot ships as a single pre-built binary. Assets (fonts, icons, locales) are
+embedded into the executable via `go:embed`, so the server does **not** need the
+`pymouse/assets/` or `locales/` trees on disk — only the binary, the `.env`
+file, and a writable directory for downloads.
+
+The repo checkout is still kept on the server as a fallback (so you can `go run`
+in an emergency) and because the bot reads `.env`, `youtubeCookies.txt`, and
+writes to `pymouse/downloads/` relative to its working directory.
+
+## Pipeline
+
+1. Push to `PyMouse` (or merge a PR) → `.github/workflows/build.yml` builds a
+   `linux/amd64` binary with `CGO_ENABLED=0` and publishes it as the artifact
+   `pymouse-linux-amd64`.
+2. On the server, `scripts/deploy.sh` downloads the latest successful artifact,
+   installs it to `/root/PyMouse/bin/pymouse`, and restarts the service.
+
+Deploy is manual on purpose — merging a PR does **not** automatically update
+production. Run `scripts/deploy.sh` when you are ready.
+
+## One-time server setup
+
+### 1. systemd unit
+
+Create `/etc/systemd/system/pymouse.service`:
+
+```ini
+[Unit]
+Description=PyMouse Bot
+After=network.target
+
+[Service]
+User=root
+WorkingDirectory=/root/PyMouse
+ExecStart=/root/PyMouse/bin/pymouse
+Restart=always
+EnvironmentFile=/root/PyMouse/.env
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Then:
+
+```bash
+systemctl daemon-reload
+systemctl enable pymouse
+```
+
+Key changes vs. the old unit:
+- `ExecStart` runs the pre-built binary instead of `go run`.
+- The `ExecStartPre=go clean -cache -modcache -i -r` line is **removed** —
+  there is nothing to compile at startup anymore, so restarts are instant.
+- `EnvironmentFile` points at `.env` (the old unit pointed at `PyMouse.log`,
+  which was incorrect).
+
+### 2. GitHub CLI
+
+`scripts/deploy.sh` uses `gh` to download artifacts. Authenticate once:
+
+```bash
+gh auth login
+```
+
+Choose GitHub.com → HTTPS, and paste a personal access token with `read`
+access to `BubbalooTeam/PyMouse` (workflow `contents: read` + `actions: read`).
+
+## Deploying
+
+```bash
+cd /root/PyMouse
+git pull                              # keep the checkout in sync (for .env, fallback)
+scripts/deploy.sh                     # pull the latest build + restart
+```
+
+To deploy a specific workflow run: `scripts/deploy.sh <run-id>`.
+
+## Rollback / fallback
+
+If the new binary misbehaves, you have two options:
+
+- **Previous binary**: re-run `scripts/deploy.sh <older-run-id>`.
+- **`go run` fallback** (the old way): temporarily point the unit back at
+  `go run` — the repo checkout is still on disk.
+
+  ```bash
+  # edit /etc/systemd/system/pymouse.service ExecStart to:
+  #   ExecStart=/usr/local/go/bin/go run /root/PyMouse/main.go
+  systemctl daemon-reload
+  systemctl restart pymouse
+  ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -5,16 +5,21 @@ embedded into the executable via `go:embed`, so the server needs only the
 binary, the `.env` file, and a writable directory for downloads — **not** the
 `pymouse/assets/` or `locales/` trees.
 
+The repo is **public**, so production binaries (GitHub Releases) download with
+plain `curl` — no token, no `gh` login. Only pre-merge PR testing needs `gh`,
+because GitHub gates workflow *artifacts* behind authentication even on public
+repos.
+
 The repo checkout is still kept on the server as a fallback (so you can `go
 run` in an emergency) and because the bot reads `.env`, `youtubeCookies.txt`,
 and writes to `pymouse/downloads/` relative to its working directory.
 
 ## How binaries are published
 
-| Trigger | What gets published | Lifetime |
-|---|---|---|
-| **Pull request** (any branch) | Workflow artifact `pymouse-linux-amd64` | 30 days |
-| **Push to `PyMouse`** (main) | **GitHub Release**, tagged `<YYYY-MM-DD>-<short-sha>` (e.g. `2026-08-04-1cc4e4d`), marked `latest` | **Permanent** |
+| Trigger | What gets published | Auth to download | Lifetime |
+|---|---|---|---|
+| **Pull request** (any branch) | Workflow artifact `pymouse-linux-amd64` | `gh` login needed | 30 days |
+| **Push to `PyMouse`** (main) | **GitHub Release**, tagged `<YYYY-MM-DD>-<short-sha>` (e.g. `2026-08-04-1cc4e4d`), marked `latest` | **None** (public URL) | **Permanent** |
 
 Releases do not expire, so every push to main is a distinct, rollback-able
 version. PR artifacts are for pre-merge testing only.
@@ -55,39 +60,41 @@ Key changes vs. the old unit:
 - `EnvironmentFile` points at `.env` (the old unit pointed at `PyMouse.log`,
   which was incorrect).
 
-### 2. GitHub CLI
+### 2. GitHub CLI (only if you'll use `deploy.sh pr`)
 
-`scripts/deploy.sh` uses `gh` to download binaries. Authenticate once:
+`deploy.sh` uses plain `curl` for releases — no auth needed. The only mode that
+needs `gh` is `deploy.sh pr` (downloading a PR workflow artifact). If you want
+to test PRs on the server before merging, authenticate once:
 
 ```bash
 gh auth login
 ```
 
 Choose GitHub.com → HTTPS, and authenticate with access to
-`BubbalooTeam/PyMouse`.
+`BubbalooTeam/PyMouse`. If you never use `pr` mode, you can skip this entirely.
 
 ## Deploying
 
 `scripts/deploy.sh` auto-detects what to install based on its argument:
 
-| Command | Installs |
-|---|---|
-| `scripts/deploy.sh` | latest release on PyMouse (the production default) |
-| `scripts/deploy.sh pr` | artifact from the latest successful PR build (pre-merge test) |
-| `scripts/deploy.sh <run-id>` | a specific PR workflow run (numeric) |
-| `scripts/deploy.sh <tag>` | a specific release tag, e.g. `2026-08-04-1cc4e4d` |
+| Command | Installs | Auth |
+|---|---|---|
+| `scripts/deploy.sh` | latest release on PyMouse (production default) | none |
+| `scripts/deploy.sh <tag>` | specific release, e.g. `2026-08-04-1cc4e4d` | none |
+| `scripts/deploy.sh pr` | artifact from the latest successful PR build | `gh` login |
+| `scripts/deploy.sh <run-id>` | a specific PR workflow run (numeric) | `gh` login |
 
 Typical flows:
 
 ```bash
-# Production update after merging a PR:
+# Production update after merging a PR (no auth needed):
 cd /root/PyMouse && git pull && scripts/deploy.sh
 
-# Test a PR before merging:
-scripts/deploy.sh pr
-
-# Roll back to a known-good version:
+# Roll back to a known-good version (no auth):
 scripts/deploy.sh 2026-08-04-1cc4e4d
+
+# Test a PR before merging (needs gh login):
+scripts/deploy.sh pr
 ```
 
 `scripts/deploy.sh` always restarts the `pymouse` service and tails the last

--- a/locales/embed.go
+++ b/locales/embed.go
@@ -1,0 +1,14 @@
+// Package locales embeds the JSON localization files shipped in this
+// directory so the compiled binary carries them without needing the
+// locales/ folder on disk at runtime.
+//
+// Files are listed explicitly (rather than via a glob like *.json) because
+// go:embed patterns cannot use globs when the directory also contains Go
+// files — every locale file must be named here. Add new locales to this
+// list when they are introduced.
+package locales
+
+import "embed"
+
+//go:embed en_us.json pt_br.json
+var Files embed.FS

--- a/pymouse/assets/assets.go
+++ b/pymouse/assets/assets.go
@@ -1,0 +1,58 @@
+// Package assets embeds the bot's static resources (fonts and icons) into the
+// binary so the compiled executable is self-contained and does not need the
+// pymouse/assets/ tree on disk at runtime.
+//
+// Callers address files using paths relative to this directory, e.g.
+// "fonts/arial.ttf" or "icons/lastfm/loved.png". The legacy
+// "pymouse/assets/..." disk paths are also accepted (the prefix is stripped),
+// which keeps `go run` development working when files are read from disk.
+package assets
+
+import (
+	"embed"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Fonts holds every bundled font file under fonts/.
+//
+//go:embed fonts/*.ttf fonts/*.otf
+var Fonts embed.FS
+
+// Icons holds every bundled icon under icons/ (lastfm, weather, ...).
+//
+//go:embed icons
+var Icons embed.FS
+
+// diskRoot is the on-disk prefix the rest of the codebase historically used to
+// address assets (relative to the repo root / the bot's working directory).
+const diskRoot = "pymouse/assets"
+
+// normalize converts either a legacy disk path ("pymouse/assets/fonts/arial.ttf")
+// or an already-embed-relative path ("fonts/arial.ttf") into the embed-relative
+// form ("fonts/arial.ttf").
+func normalize(path string) string {
+	p := strings.TrimPrefix(path, diskRoot+"/")
+	return strings.TrimPrefix(p, "./")
+}
+
+// readFirstEmbed tries each embed.FS in turn, returning the first that contains
+// the (embed-relative) name. On miss it falls back to disk so that unbundled
+// `go run` development still works.
+func readFirstEmbed(name string, fss ...embed.FS) ([]byte, error) {
+	for _, fs := range fss {
+		if b, err := fs.ReadFile(name); err == nil {
+			return b, nil
+		}
+	}
+	return os.ReadFile(filepath.Join(diskRoot, name))
+}
+
+// ReadFile returns the bytes of any bundled asset (font or icon), addressed by
+// embed-relative path or legacy disk path. It tries the embedded copy first
+// and falls back to disk.
+func ReadFile(path string) ([]byte, error) {
+	name := normalize(path)
+	return readFirstEmbed(name, Fonts, Icons)
+}

--- a/pymouse/helpers/i18n/i18n.go
+++ b/pymouse/helpers/i18n/i18n.go
@@ -3,8 +3,10 @@ package i18n
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"pymouse/locales"
 	"pymouse/pymouse/database/repositories"
 	"strings"
 
@@ -23,36 +25,49 @@ var defaultLanguage = "en_us"
 var StringsCache = make(map[string]map[string]interface{})
 
 func CompileLocales() error {
-	dir := "locales"
+	// Load locale files from the embedded locales.Files first; fall back to
+	// the on-disk "locales/" directory so `go run` without the embed still
+	// works during development.
+	load := func(name string, data []byte) error {
+		langCode := strings.TrimSuffix(name, filepath.Ext(name))
 
-	err := filepath.Walk(
-		dir,
-		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return fmt.Errorf("Failed to retrieve localization file: %v", err)
-			}
+		langMap := make(map[string]interface{})
+		if err := json.Unmarshal(data, &langMap); err != nil {
+			return fmt.Errorf("Failed to unmarshal data from localization file %q.", name)
+		}
 
-			if !info.IsDir() && filepath.Ext(path) == ".json" {
-				langCode := filepath.Base(path[:len(path)-len(filepath.Ext(path))])
+		StringsCache[langCode] = langMap
+		AvalaibleLanguages = append(AvalaibleLanguages, langCode)
+		return nil
+	}
 
-				data, err := os.ReadFile(path)
-				if err != nil {
-					return fmt.Errorf("Failed to read localization file: %v", err)
-				}
-
-				langMap := make(map[string]interface{})
-				err = json.Unmarshal(data, &langMap)
-				if err != nil {
-					return fmt.Errorf("Failed to unmarshal data from localization file.")
-				}
-
-				StringsCache[langCode] = langMap
-				AvalaibleLanguages = append(AvalaibleLanguages, langCode)
-			}
+	walkErr := fs.WalkDir(locales.Files, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve localization file: %v", err)
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
 			return nil
-		},
-	)
-	return err
+		}
+		data, rerr := locales.Files.ReadFile(path)
+		if rerr != nil {
+			return fmt.Errorf("Failed to read localization file: %v", rerr)
+		}
+		return load(filepath.Base(path), data)
+	})
+	if walkErr != nil {
+		// Fallback: try the on-disk "locales/" directory (e.g. unbundled go run).
+		return filepath.Walk("locales", func(path string, info os.FileInfo, ferr error) error {
+			if ferr != nil || info.IsDir() || filepath.Ext(path) != ".json" {
+				return ferr
+			}
+			data, rerr := os.ReadFile(path)
+			if rerr != nil {
+				return fmt.Errorf("Failed to read localization file: %v", rerr)
+			}
+			return load(filepath.Base(path), data)
+		})
+	}
+	return nil
 }
 
 func GetStringFromNestedMap(langMap map[string]interface{}, key string) string {

--- a/pymouse/modules/lastfm/lfm/utils.go
+++ b/pymouse/modules/lastfm/lfm/utils.go
@@ -1,6 +1,7 @@
 package lfm
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"image"
@@ -8,6 +9,7 @@ import (
 	"image/jpeg"
 	"net/http"
 	"os"
+	"pymouse/pymouse/assets"
 	"pymouse/pymouse/config"
 	"pymouse/pymouse/helpers/rapidhttp"
 	"pymouse/pymouse/modules/lastfm/set"
@@ -182,7 +184,7 @@ func getListeningText(trackInfo LastFMTrackInformations, l func(string) string) 
 }
 
 func loadFont(path string, size float64) font.Face {
-	b, err := os.ReadFile(path)
+	b, err := assets.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}
@@ -452,9 +454,11 @@ func DrawScrobble(
 
 	// loved
 	if loved {
-		if heart, err := imaging.Open("pymouse/assets/icons/lastfm/loved.png"); err == nil {
-			heart = imaging.Resize(heart, 25, 25, imaging.Lanczos)
-			dc.DrawImage(heart, 248, 190)
+		if heartBytes, err := assets.ReadFile("icons/lastfm/loved.png"); err == nil {
+			if heart, derr := imaging.Decode(bytes.NewReader(heartBytes)); derr == nil {
+				heart = imaging.Resize(heart, 25, 25, imaging.Lanczos)
+				dc.DrawImage(heart, 248, 190)
+			}
 		}
 
 		dc.SetFontFace(arial23)

--- a/pymouse/modules/miscellaneous/weather/utils.go
+++ b/pymouse/modules/miscellaneous/weather/utils.go
@@ -1,6 +1,7 @@
 package weather
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"image"
@@ -8,15 +9,19 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"pymouse/pymouse/assets"
 	"pymouse/pymouse/config"
 	"pymouse/pymouse/helpers/rapidhttp"
 	"pymouse/pymouse/helpers/utils"
 	"strings"
 	"time"
 
+	"github.com/disintegration/imaging"
 	"github.com/fogleman/gg"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/opentype"
 )
 
 type weatherLocationResponse struct {
@@ -138,9 +143,14 @@ var weatherIconCache = map[int]image.Image{}
 func init() {
 	for code, path := range weatherIconPaths {
 
-		img, err := gg.LoadImage(path)
+		iconBytes, err := assets.ReadFile(path)
 		if err != nil {
-			logrus.Error("failed loading icon:", path, err)
+			logrus.Error("failed reading icon:", path, err)
+			continue
+		}
+		img, err := imaging.Decode(bytes.NewReader(iconBytes))
+		if err != nil {
+			logrus.Error("failed decoding icon:", path, err)
 			continue
 		}
 
@@ -158,6 +168,30 @@ func init() {
 
 		weatherIconCache[code] = im.Image()
 	}
+}
+
+// loadFontFace is an embed-aware drop-in replacement for gg.Context.LoadFontFace.
+// It reads the font via the embedded assets (with on-disk fallback) and installs
+// it as the context's current face, mirroring the original error contract.
+func loadFontFace(dc *gg.Context, path string, points float64) error {
+	b, err := assets.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	ft, err := opentype.Parse(b)
+	if err != nil {
+		return err
+	}
+	face, err := opentype.NewFace(ft, &opentype.FaceOptions{
+		Size:    points,
+		DPI:     72,
+		Hinting: font.HintingFull,
+	})
+	if err != nil {
+		return err
+	}
+	dc.SetFontFace(face)
+	return nil
 }
 
 func GetIconImage(iconCode int) image.Image {
@@ -358,7 +392,7 @@ func MakeWeatherInterface(
 	im.DrawRectangle(0, 0, width, height)
 	im.Fill()
 
-	if err := im.LoadFontFace("pymouse/assets/fonts/economica-italic.ttf", 80); err != nil {
+	if err := loadFontFace(im, "pymouse/assets/fonts/economica-italic.ttf", 80); err != nil {
 		return "", err
 	}
 
@@ -367,7 +401,7 @@ func MakeWeatherInterface(
 	im.SetRGB(1, 1, 1)
 	im.DrawStringAnchored(locationText, width/2, 120, 0.5, 0.5)
 
-	if err := im.LoadFontFace("pymouse/assets/fonts/notosans-bold.ttf", 80); err != nil {
+	if err := loadFontFace(im, "pymouse/assets/fonts/notosans-bold.ttf", 80); err != nil {
 		return "", err
 	}
 	yCurrent := 400.0
@@ -385,7 +419,7 @@ func MakeWeatherInterface(
 		yCurrent+80,
 	)
 
-	if err := im.LoadFontFace("pymouse/assets/fonts/economica-italic.ttf", 80); err != nil {
+	if err := loadFontFace(im, "pymouse/assets/fonts/economica-italic.ttf", 80); err != nil {
 		return "", err
 	}
 
@@ -395,7 +429,7 @@ func MakeWeatherInterface(
 		yCurrent+180,
 	)
 
-	if err := im.LoadFontFace("pymouse/assets/fonts/arial.ttf", 65); err != nil {
+	if err := loadFontFace(im, "pymouse/assets/fonts/arial.ttf", 65); err != nil {
 		return "", err
 	}
 
@@ -448,13 +482,13 @@ func MakeWeatherInterface(
 
 		dayLabel := utils.FirstRunes(daily.Date, 3)
 
-		if err := im.LoadFontFace("pymouse/assets/fonts/notosans-bold.ttf", 60); err != nil {
+		if err := loadFontFace(im, "pymouse/assets/fonts/notosans-bold.ttf", 60); err != nil {
 			return "", err
 		}
 		im.SetRGB(1, 1, 1)
 		im.DrawString(dayLabel, xStart, yForecast+260)
 
-		if err := im.LoadFontFace("pymouse/assets/fonts/arial.ttf", 60); err != nil {
+		if err := loadFontFace(im, "pymouse/assets/fonts/arial.ttf", 60); err != nil {
 			return "", err
 		}
 
@@ -479,7 +513,7 @@ func MakeWeatherInterface(
 			shortcast = shortcast[:18] + "..."
 		}
 
-		if err := im.LoadFontFace("pymouse/assets/fonts/arial.ttf", 35); err != nil {
+		if err := loadFontFace(im, "pymouse/assets/fonts/arial.ttf", 35); err != nil {
 			return "", err
 		}
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# deploy.sh — pull the latest pre-built PyMouse binary from GitHub Actions and
+# restart the systemd service on this host.
+#
+# Requirements on the server:
+#   - GitHub CLI (gh) installed and authenticated (gh auth login) with read
+#     access to BubbalooTeam/PyMouse.
+#   - The systemd unit "pymouse" configured to run ExecStart=/root/PyMouse/bin/pymouse
+#     (see deploy/README.md or the PR description for the unit file).
+#   - /root/PyMouse checked out (kept as a fallback to `go run` and to host
+#     .env / youtubeCookies.txt / the downloads dir).
+#
+# Usage:
+#   scripts/deploy.sh            # deploy latest run on PyMouse (default)
+#   scripts/deploy.sh <run-id>   # deploy a specific workflow run
+#
+set -euo pipefail
+
+REPO="BubbalooTeam/PyMouse"
+BRANCH="${PYMOUSE_DEPLOY_BRANCH:-PyMouse}"
+INSTALL_DIR="${PYMOUSE_INSTALL_DIR:-/root/PyMouse}"
+BIN_PATH="${INSTALL_DIR}/bin/pymouse"
+ARTIFACT_NAME="pymouse-linux-amd64"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$INSTALL_DIR"
+
+echo "==> Fetching latest successful build on '$BRANCH'..."
+if [[ -n "${1:-}" ]]; then
+  RUN_ID="$1"
+else
+  RUN_ID="$(gh run list \
+    --repo "$REPO" \
+    --branch "$BRANCH" \
+    --workflow build.yml \
+    --status success \
+    --limit 1 \
+    --json databaseId \
+    --jq '.[0].databaseId')"
+fi
+
+if [[ -z "$RUN_ID" ]]; then
+  echo "ERROR: no successful build found on '$BRANCH'. Trigger a push first." >&2
+  exit 1
+fi
+
+echo "==> Using run $RUN_ID"
+echo "==> Downloading artifact '$ARTIFACT_NAME'..."
+gh run download "$RUN_ID" \
+  --repo "$REPO" \
+  --name "$ARTIFACT_NAME" \
+  --dir "$TMP_DIR"
+
+if [[ ! -f "$TMP_DIR/pymouse" ]]; then
+  echo "ERROR: artifact did not contain 'pymouse' binary." >&2
+  exit 1
+fi
+
+echo "==> Installing to $BIN_PATH"
+mkdir -p "$(dirname "$BIN_PATH")"
+install -m 0755 "$TMP_DIR/pymouse" "$BIN_PATH"
+
+echo "==> Restarting pymouse.service"
+systemctl restart pymouse
+
+echo "==> Done. Tailing logs (Ctrl-C to exit)..."
+journalctl -u pymouse -n 20 --no-pager

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 #
-# deploy.sh — pull the latest pre-built PyMouse binary from GitHub Actions and
-# restart the systemd service on this host.
+# deploy.sh — install a pre-built PyMouse binary and restart the service.
+#
+# Three modes (the script auto-detects which based on $1):
+#
+#   scripts/deploy.sh                 # latest release on PyMouse (production)
+#   scripts/deploy.sh pr              # workflow artifact from the latest PR run
+#   scripts/deploy.sh <tag>           # a specific release tag (e.g. 2026-08-04-1cc4e4d)
+#   scripts/deploy.sh <run-id>        # a specific PR workflow run id (numeric)
 #
 # Requirements on the server:
 #   - GitHub CLI (gh) installed and authenticated (gh auth login) with read
 #     access to BubbalooTeam/PyMouse.
-#   - The systemd unit "pymouse" configured to run ExecStart=/root/PyMouse/bin/pymouse
-#     (see deploy/README.md or the PR description for the unit file).
-#   - /root/PyMouse checked out (kept as a fallback to `go run` and to host
-#     .env / youtubeCookies.txt / the downloads dir).
-#
-# Usage:
-#   scripts/deploy.sh            # deploy latest run on PyMouse (default)
-#   scripts/deploy.sh <run-id>   # deploy a specific workflow run
+#   - The systemd unit "pymouse" configured to run ExecStart=$BIN_PATH.
+#   - The repo checked out at $INSTALL_DIR (kept for .env, youtubeCookies.txt,
+#     the downloads dir, and as a `go run` fallback).
 #
 set -euo pipefail
 
 REPO="BubbalooTeam/PyMouse"
-BRANCH="${PYMOUSE_DEPLOY_BRANCH:-PyMouse}"
 INSTALL_DIR="${PYMOUSE_INSTALL_DIR:-/root/PyMouse}"
 BIN_PATH="${INSTALL_DIR}/bin/pymouse"
 ARTIFACT_NAME="pymouse-linux-amd64"
@@ -27,35 +27,53 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 cd "$INSTALL_DIR"
 
-echo "==> Fetching latest successful build on '$BRANCH'..."
-if [[ -n "${1:-}" ]]; then
-  RUN_ID="$1"
+# Resolve the requested binary into "$TMP_DIR/pymouse".
+arg="${1:-}"
+downloaded=0
+
+is_number() { [[ "$1" =~ ^[0-9]+$ ]]; }
+
+if [[ -z "$arg" || "$arg" == "latest" ]]; then
+    # --- latest release on PyMouse (the production default) ---
+    echo "==> Downloading latest release from $REPO..."
+    gh release download --repo "$REPO" --pattern pymouse --dir "$TMP_DIR" --clobber
+    downloaded=1
+
+elif [[ "$arg" == "pr" ]]; then
+    # --- latest PR workflow artifact (for pre-merge testing) ---
+    echo "==> Locating latest successful PR build run..."
+    RUN_ID="$(gh run list \
+        --repo "$REPO" \
+        --workflow build.yml \
+        --event pull_request \
+        --status success \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId')"
+    if [[ -z "$RUN_ID" ]]; then
+        echo "ERROR: no successful PR build found. Push to the PR branch first." >&2
+        exit 1
+    fi
+    echo "==> Using PR run $RUN_ID"
+    gh run download "$RUN_ID" --repo "$REPO" --name "$ARTIFACT_NAME" --dir "$TMP_DIR"
+    downloaded=1
+
+elif is_number "$arg"; then
+    # --- numeric: a specific workflow run id (artifact) ---
+    echo "==> Downloading artifact from run $arg..."
+    gh run download "$arg" --repo "$REPO" --name "$ARTIFACT_NAME" --dir "$TMP_DIR"
+    downloaded=1
+
 else
-  RUN_ID="$(gh run list \
-    --repo "$REPO" \
-    --branch "$BRANCH" \
-    --workflow build.yml \
-    --status success \
-    --limit 1 \
-    --json databaseId \
-    --jq '.[0].databaseId')"
+    # --- otherwise: treat $arg as a release tag ---
+    echo "==> Downloading release '$arg' from $REPO..."
+    gh release download "$arg" --repo "$REPO" --pattern pymouse --dir "$TMP_DIR" --clobber
+    downloaded=1
 fi
 
-if [[ -z "$RUN_ID" ]]; then
-  echo "ERROR: no successful build found on '$BRANCH'. Trigger a push first." >&2
-  exit 1
-fi
-
-echo "==> Using run $RUN_ID"
-echo "==> Downloading artifact '$ARTIFACT_NAME'..."
-gh run download "$RUN_ID" \
-  --repo "$REPO" \
-  --name "$ARTIFACT_NAME" \
-  --dir "$TMP_DIR"
-
-if [[ ! -f "$TMP_DIR/pymouse" ]]; then
-  echo "ERROR: artifact did not contain 'pymouse' binary." >&2
-  exit 1
+if [[ "$downloaded" -ne 1 ]] || [[ ! -f "$TMP_DIR/pymouse" ]]; then
+    echo "ERROR: binary was not downloaded to $TMP_DIR/pymouse." >&2
+    exit 1
 fi
 
 echo "==> Installing to $BIN_PATH"
@@ -65,5 +83,5 @@ install -m 0755 "$TMP_DIR/pymouse" "$BIN_PATH"
 echo "==> Restarting pymouse.service"
 systemctl restart pymouse
 
-echo "==> Done. Tailing logs (Ctrl-C to exit)..."
+echo "==> Done. Recent logs:"
 journalctl -u pymouse -n 20 --no-pager

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,19 +2,22 @@
 #
 # deploy.sh — install a pre-built PyMouse binary and restart the service.
 #
-# Three modes (the script auto-detects which based on $1):
+# The repo is public, so RELEASES can be downloaded with plain curl — no token,
+# no gh login. Only PR-mode (downloading a workflow artifact) needs gh auth,
+# because GitHub gates workflow artifacts behind authentication even on public
+# repos.
+#
+# Modes (auto-detected from $1):
 #
 #   scripts/deploy.sh                 # latest release on PyMouse (production)
-#   scripts/deploy.sh pr              # workflow artifact from the latest PR run
-#   scripts/deploy.sh <tag>           # a specific release tag (e.g. 2026-08-04-1cc4e4d)
-#   scripts/deploy.sh <run-id>        # a specific PR workflow run id (numeric)
+#   scripts/deploy.sh <tag>           # specific release tag (e.g. 2026-08-04-1cc4e4d)
+#   scripts/deploy.sh pr              # latest PR workflow artifact (needs gh auth)
+#   scripts/deploy.sh <run-id>        # specific PR workflow run id (needs gh auth)
 #
-# Requirements on the server:
-#   - GitHub CLI (gh) installed and authenticated (gh auth login) with read
-#     access to BubbalooTeam/PyMouse.
-#   - The systemd unit "pymouse" configured to run ExecStart=$BIN_PATH.
-#   - The repo checked out at $INSTALL_DIR (kept for .env, youtubeCookies.txt,
-#     the downloads dir, and as a `go run` fallback).
+# Requirements:
+#   - curl (always) and gh (only for `pr` / `<run-id>` modes).
+#   - systemd unit "pymouse" configured with ExecStart=$BIN_PATH.
+#   - Repo checked out at $INSTALL_DIR (for .env, downloads dir, fallback).
 #
 set -euo pipefail
 
@@ -27,51 +30,52 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 cd "$INSTALL_DIR"
 
-# Resolve the requested binary into "$TMP_DIR/pymouse".
-arg="${1:-}"
-downloaded=0
-
 is_number() { [[ "$1" =~ ^[0-9]+$ ]]; }
 
-if [[ -z "$arg" || "$arg" == "latest" ]]; then
-    # --- latest release on PyMouse (the production default) ---
-    echo "==> Downloading latest release from $REPO..."
-    gh release download --repo "$REPO" --pattern pymouse --dir "$TMP_DIR" --clobber
-    downloaded=1
+arg="${1:-}"
 
-elif [[ "$arg" == "pr" ]]; then
-    # --- latest PR workflow artifact (for pre-merge testing) ---
-    echo "==> Locating latest successful PR build run..."
-    RUN_ID="$(gh run list \
-        --repo "$REPO" \
-        --workflow build.yml \
-        --event pull_request \
-        --status success \
-        --limit 1 \
-        --json databaseId \
-        --jq '.[0].databaseId')"
-    if [[ -z "$RUN_ID" ]]; then
-        echo "ERROR: no successful PR build found. Push to the PR branch first." >&2
+# Resolve the requested binary into "$TMP_DIR/pymouse".
+if [[ -z "$arg" || "$arg" == "latest" ]]; then
+    # --- latest release (public, no auth) ---
+    echo "==> Downloading latest release from $REPO..."
+    curl -fL --retry 3 -o "$TMP_DIR/pymouse" \
+        "https://github.com/$REPO/releases/latest/download/pymouse"
+
+elif [[ "$arg" == "pr" ]] || is_number "$arg"; then
+    # --- workflow artifact (needs gh; GitHub gates artifacts even on public repos) ---
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "ERROR: 'gh' is required for PR/run-id mode but was not found." >&2
+        echo "       Install it (https://cli.github.com) and run 'gh auth login'." >&2
         exit 1
     fi
-    echo "==> Using PR run $RUN_ID"
+    if [[ "$arg" == "pr" ]]; then
+        echo "==> Locating latest successful PR build run..."
+        RUN_ID="$(gh run list \
+            --repo "$REPO" \
+            --workflow build.yml \
+            --event pull_request \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')"
+        if [[ -z "$RUN_ID" ]]; then
+            echo "ERROR: no successful PR build found. Push to the PR branch first." >&2
+            exit 1
+        fi
+    else
+        RUN_ID="$arg"
+    fi
+    echo "==> Downloading artifact from run $RUN_ID..."
     gh run download "$RUN_ID" --repo "$REPO" --name "$ARTIFACT_NAME" --dir "$TMP_DIR"
-    downloaded=1
-
-elif is_number "$arg"; then
-    # --- numeric: a specific workflow run id (artifact) ---
-    echo "==> Downloading artifact from run $arg..."
-    gh run download "$arg" --repo "$REPO" --name "$ARTIFACT_NAME" --dir "$TMP_DIR"
-    downloaded=1
 
 else
-    # --- otherwise: treat $arg as a release tag ---
+    # --- specific release tag (public, no auth) ---
     echo "==> Downloading release '$arg' from $REPO..."
-    gh release download "$arg" --repo "$REPO" --pattern pymouse --dir "$TMP_DIR" --clobber
-    downloaded=1
+    curl -fL --retry 3 -o "$TMP_DIR/pymouse" \
+        "https://github.com/$REPO/releases/download/$arg/pymouse"
 fi
 
-if [[ "$downloaded" -ne 1 ]] || [[ ! -f "$TMP_DIR/pymouse" ]]; then
+if [[ ! -f "$TMP_DIR/pymouse" ]]; then
     echo "ERROR: binary was not downloaded to $TMP_DIR/pymouse." >&2
     exit 1
 fi


### PR DESCRIPTION
## Why

The current deployment compiles the bot on **every restart**:

```ini
ExecStartPre=/usr/local/go/bin/go clean -cache -modcache -i -r
ExecStart=/usr/local/go/bin/go run /root/PyMouse/main.go
```

The `go clean -cache -modcache` in `ExecStartPre` wipes the entire build cache before each start, so every restart is a **cold recompile from scratch** plus re-downloading all dependencies. Observed in the journal: ~2–3 min of `go: downloading ...` + compilation before the bot actually comes up.

This PR replaces that with a **pre-built, self-contained binary** built by CI. Restarts become instant (just `exec` the binary, no compilation).

## What changes

### 1. Assets embedded into the binary (`go:embed`)

The binary no longer needs `pymouse/assets/` or `locales/` on disk — fonts, icons, and locale files are embedded directly into the executable.

- **New `pymouse/assets` package** — `Fonts` and `Icons` `embed.FS`, plus a `ReadFile(path)` helper with a **dual-path design**: tries the embedded copy first, falls back to the on-disk file if not bundled. This keeps `go run` development working exactly as before (zero regression) while making the production binary independent of the source tree.
- **New `locales` package** — `Files` `embed.FS` for the localization JSONs.

### 2. Asset readers migrated to embed (with disk fallback)

| File | Change |
|---|---|
| `pymouse/helpers/i18n` | `CompileLocales` walks `locales.Files` first, falls back to disk `filepath.Walk(\"locales\")` |
| `pymouse/modules/lastfm/lfm` | `loadFont` reads via `assets.ReadFile`; loved-heart PNG uses `imaging.Decode(bytes.NewReader(...))` instead of `imaging.Open` |
| `pymouse/modules/miscellaneous/weather` | icon cache reads via `assets.ReadFile`; 7 `im.LoadFontFace` call sites use a local `loadFontFace` helper that parses via `opentype` from embedded bytes |

### 3. CI (`.github/workflows/build.yml`)

On push to `PyMouse` and on PRs: `go vet` + build `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags=\"-s -w\"`, then upload the binary as artifact `pymouse-linux-amd64` (push runs only).

Cross-compile with `CGO_ENABLED=0` is safe — the project has **no cgo dependencies**.

### 4. Deploy (`scripts/deploy.sh` + `deploy/README.md`)

`scripts/deploy.sh` downloads the latest successful build artifact via `gh`, installs it to `/root/PyMouse/bin/pymouse`, and restarts the `pymouse` service. **Deploy is manual** — no auto-deploy by design (merging this PR does not touch production).

The systemd unit change (documented in `deploy/README.md`):

```diff
-ExecStartPre=/usr/local/go/bin/go clean -cache -modcache -i -r
-ExecStart=/usr/local/go/bin/go run /root/PyMouse/main.go
+ExecStart=/root/PyMouse/bin/pymouse
```

## Validation

- ✅ `go build ./...` clean
- ✅ `go vet ./...` clean
- ✅ Binary built with the exact CI flags (`CGO=0 -trimpath -ldflags=\"-s -w\"`)
- ✅ **Regression test (the important one):** ran a binary that imports the asset/locale packages from an **empty working directory** (no `pymouse/assets/`, no `locales/` on disk). All fonts (incl. the 16 MB Noto CJK), the loved/weather PNG icons, and both locale JSONs loaded successfully from the embed FS — proving the binary is truly self-contained for static resources.
- ✅ The disk fallback is exercised only when the embed misses (i.e. during `go run` development).

## Binary size

The compiled binary is ~37 MB (assets embedded — dominated by the 16 MB Noto Sans CJK font from PR #1). This is a trade-off for self-containment; acceptable for a single-instance bot.

## Out of scope (intentional)

- **No auto-deploy webhook** — manual `scripts/deploy.sh` is safer.
- **Repo checkout stays on the server** as a `go run` fallback in case the binary misbehaves.
- `.env`, `pymouse/downloads/`, `PyMouse.log`, `youtubeCookies.txt` remain on disk (runtime state / secrets / user data — not embeddable).

## Deploy after merge

See `deploy/README.md` for the full one-time server setup (systemd unit change + `gh auth login`). After that, each deploy is:

```bash
cd /root/PyMouse && git pull && scripts/deploy.sh
```