### PR TITLE
feat(lastfm): neutral caption, link buttons, and inline mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ OWNER_ID="1234567890"
 SOCKS5_PROXY="SOCKS5_PROXY" # Optional
 TELEGRAM_API_URL="YOUR_TELEGRAM_API_URL" # Optional
 WEBHOOK_URL="YOUR_WEBHOOK_URL" # Optional
+
+# Cloudflare R2 (Optional — enables card images in @PyMouseBOT lfm inline results).
+# All five must be set together; when unset, inline results fall back to text.
+R2_ACCOUNT_ID="your-cloudflare-account-id"
+R2_BUCKET="pymouse-inline"
+R2_ACCESS_KEY_ID="your-r2-access-key-id"
+R2_SECRET_ACCESS_KEY="your-r2-secret-access-key"
+R2_PUBLIC_URL="https://lfm-img.yourdomain.com"

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -161,6 +161,9 @@
             "loved": "liked this song",
             "error": "<b>An error occurred while retrieving the user's playback information.</b>"
 
+        },
+        "inline": {
+            "profile": "Last.fm profile"
         }
 },
     "pm-menu": {

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -168,6 +168,7 @@
         "recent": {
             "header": "recent tracks",
             "profile-btn": "Profile",
+            "expand-btn": "Recent",
             "back-btn": "Back",
             "share-btn": "Share",
             "not-yours": "This isn't your card."

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -167,6 +167,7 @@
         },
         "recent": {
             "header": "recent tracks",
+            "now-label": "current",
             "profile-btn": "Profile",
             "expand-btn": "Recent",
             "back-btn": "Back",

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -158,7 +158,7 @@
             "no-scrobbles": "<b>The user has not listened to any music.</b>",
             "userplaycount": " for the %dth time",
             "was-listening": "Was listening",
-            "loved": "He/She liked this song!",
+            "loved": "liked this song",
             "error": "<b>An error occurred while retrieving the user's playback information.</b>"
 
         }

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -164,6 +164,13 @@
         },
         "inline": {
             "profile": "Last.fm profile"
+        },
+        "recent": {
+            "header": "recent tracks",
+            "profile-btn": "Profile",
+            "back-btn": "Back",
+            "share-btn": "Share",
+            "not-yours": "This isn't your card."
         }
 },
     "pm-menu": {

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -170,6 +170,7 @@
         },
         "recent": {
             "header": "últimas faixas",
+            "now-label": "atual",
             "profile-btn": "Perfil",
             "expand-btn": "Últimas",
             "back-btn": "Voltar",

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -164,6 +164,9 @@
             "was-listening": "Estava ouvindo",
             "loved": "curtiu essa música",
             "error": "<b>Ocorreu um erro ao obter as informações de reprodução do usuário.</b>"
+        },
+        "inline": {
+            "profile": "Perfil Last.fm"
         }
     },
     "pm-menu": {

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -171,6 +171,7 @@
         "recent": {
             "header": "últimas faixas",
             "profile-btn": "Perfil",
+            "expand-btn": "Últimas",
             "back-btn": "Voltar",
             "share-btn": "Compartilhar",
             "not-yours": "Esse card não é seu."

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -167,6 +167,13 @@
         },
         "inline": {
             "profile": "Perfil Last.fm"
+        },
+        "recent": {
+            "header": "últimas faixas",
+            "profile-btn": "Perfil",
+            "back-btn": "Voltar",
+            "share-btn": "Compartilhar",
+            "not-yours": "Esse card não é seu."
         }
     },
     "pm-menu": {

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -162,7 +162,7 @@
             "no-scrobbles": "<b>Nenhuma música foi ouvida pelo usuário.</b>",
             "userplaycount": " pela %dª vez",
             "was-listening": "Estava ouvindo",
-            "loved": "Ele(a) curtiu essa música!",
+            "loved": "curtiu essa música",
             "error": "<b>Ocorreu um erro ao obter as informações de reprodução do usuário.</b>"
         }
     },

--- a/pymouse/client/bot.go
+++ b/pymouse/client/bot.go
@@ -22,6 +22,17 @@ func GetUpdates(ctx context.Context, bot *telego.Bot, webhookURL string) (<-chan
 	var updates <-chan telego.Update
 	var err error
 
+	// Explicitly opt into the update types we handle. Long polling defaults
+	// to the previously-sent set after the first call, which can drop
+	// inline_query/callback_query — so we list everything we need here.
+	allowedUpdates := []string{
+		"message",
+		"edited_message",
+		"inline_query",
+		"chosen_inline_result",
+		"callback_query",
+	}
+
 	bot.DeleteWebhook(
 		ctx,
 		&telego.DeleteWebhookParams{
@@ -30,7 +41,8 @@ func GetUpdates(ctx context.Context, bot *telego.Bot, webhookURL string) (<-chan
 	)
 	if webhookURL == "" {
 		updates, err = bot.UpdatesViaLongPolling(ctx, &telego.GetUpdatesParams{
-			Timeout: 4,
+			Timeout:        4,
+			AllowedUpdates: allowedUpdates,
 		}, telego.WithLongPollingUpdateInterval(0))
 		if err != nil {
 			return nil, err
@@ -39,7 +51,8 @@ func GetUpdates(ctx context.Context, bot *telego.Bot, webhookURL string) (<-chan
 		err := bot.SetWebhook(
 			ctx,
 			&telego.SetWebhookParams{
-				URL: webhookURL + bot.Token(),
+				URL:            webhookURL + bot.Token(),
+				AllowedUpdates: allowedUpdates,
 			},
 		)
 		if err != nil {

--- a/pymouse/config/config.go
+++ b/pymouse/config/config.go
@@ -18,6 +18,15 @@ var (
 	Socks5Proxy    string
 	TelegramAPIURL string
 	WebhookURL     string
+
+	// Cloudflare R2 (optional). When all four are set, the last.fm inline
+	// result uploads its card image to R2 and serves it via R2PublicURL.
+	// When unset, the inline result falls back to a plain text article.
+	R2AccountID    string
+	R2Bucket       string
+	R2AccessKeyID  string
+	R2SecretKey    string
+	R2PublicURL    string
 )
 
 func init() {
@@ -56,4 +65,11 @@ func init() {
 	Socks5Proxy = os.Getenv("SOCKS5_PROXY")
 	TelegramAPIURL = os.Getenv("TELEGRAM_API_URL")
 	WebhookURL = os.Getenv("WEBHOOK_URL")
+
+	// R2 is optional — only read if present.
+	R2AccountID = os.Getenv("R2_ACCOUNT_ID")
+	R2Bucket = os.Getenv("R2_BUCKET")
+	R2AccessKeyID = os.Getenv("R2_ACCESS_KEY_ID")
+	R2SecretKey = os.Getenv("R2_SECRET_ACCESS_KEY")
+	R2PublicURL = os.Getenv("R2_PUBLIC_URL")
 }

--- a/pymouse/modules/lastfm/lfm/callbacks.go
+++ b/pymouse/modules/lastfm/lfm/callbacks.go
@@ -154,7 +154,7 @@ func BackToNowPlaying(ctx *telegohandler.Context, update telego.Update) error {
 	}()
 
 	rows := [][]telego.InlineKeyboardButton{{
-		{Text: "▶️ YouTube", URL: trackInfo.YouTubeURL},
+		{Text: "🎵 Last.fm", URL: trackInfo.LastFMURL},
 		{Text: "👤 " + l("lastfm.recent.profile-btn"), URL: "https://www.last.fm/user/" + username},
 		{Text: "📋 " + l("lastfm.recent.expand-btn"), CallbackData: fmt.Sprintf("lfm_recent|%d", ownerID)},
 	}}

--- a/pymouse/modules/lastfm/lfm/callbacks.go
+++ b/pymouse/modules/lastfm/lfm/callbacks.go
@@ -90,7 +90,7 @@ func ExpandRecent(ctx *telegohandler.Context, update telego.Update) error {
 
 	profileBtn := []telego.InlineKeyboardButton{
 		{Text: "👤 " + l("lastfm.recent.profile-btn"), URL: "https://www.last.fm/user/" + username},
-		{Text: "← " + l("lastfm.recent.back-btn"), CallbackData: fmt.Sprintf("lfm_back|%d", ownerID)},
+		{Text: "↩️ " + l("lastfm.recent.back-btn"), CallbackData: fmt.Sprintf("lfm_back|%d", ownerID)},
 	}
 
 	if _, err := bot.EditMessageMedia(ctx, &telego.EditMessageMediaParams{
@@ -153,12 +153,10 @@ func BackToNowPlaying(ctx *telegohandler.Context, update telego.Update) error {
 		os.Remove(imgPath)
 	}()
 
-	shareQuery := "lfm"
 	rows := [][]telego.InlineKeyboardButton{{
 		{Text: "▶️ YouTube", URL: trackInfo.YouTubeURL},
 		{Text: "👤 " + l("lastfm.recent.profile-btn"), URL: "https://www.last.fm/user/" + username},
-		{Text: "+", CallbackData: fmt.Sprintf("lfm_recent|%d", ownerID)},
-		{Text: "🔗 " + l("lastfm.recent.share-btn"), SwitchInlineQuery: &shareQuery},
+		{Text: "📋 " + l("lastfm.recent.expand-btn"), CallbackData: fmt.Sprintf("lfm_recent|%d", ownerID)},
 	}}
 
 	if _, err := bot.EditMessageMedia(ctx, &telego.EditMessageMediaParams{

--- a/pymouse/modules/lastfm/lfm/callbacks.go
+++ b/pymouse/modules/lastfm/lfm/callbacks.go
@@ -1,0 +1,179 @@
+package lfm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"pymouse/pymouse/database/repositories"
+	"pymouse/pymouse/helpers/i18n"
+	"pymouse/pymouse/helpers/rapidhttp"
+	"strconv"
+	"strings"
+
+	"github.com/cavaliergopher/grab/v3"
+	"github.com/mymmrac/telego"
+	"github.com/mymmrac/telego/telegohandler"
+	"github.com/mymmrac/telego/telegoutil"
+)
+
+// recentLimit is how many scrobbles the "+" button expands to.
+const recentLimit = 5
+
+// fontSet is the same Fonts literal used by NowPlaying; kept here so the
+// callback handlers can regenerate cards without duplicating the paths.
+func fontSet() Fonts {
+	return Fonts{
+		OpenSans: "pymouse/assets/fonts/opensans.ttf",
+		Poppins:  "pymouse/assets/fonts/poppins-semibolditalic.ttf",
+		Arial:    "pymouse/assets/fonts/arial.ttf",
+		Unicode:  "pymouse/assets/fonts/notosans-unicode.ttf",
+		CJK:      "pymouse/assets/fonts/notosanscjk-sc.otf",
+	}
+}
+
+// parseOwner extracts the owner userID from a "prefix|userID" callback data
+// and reports whether the caller is that owner.
+func parseOwner(data string, fromID int64) (int64, bool) {
+	parts := strings.Split(data, "|")
+	if len(parts) != 2 {
+		return 0, false
+	}
+	uid, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return uid, uid == fromID
+}
+
+// denyOthers answers the callback with an alert when someone other than the
+// card's owner taps the button.
+func denyOthers(bot *telego.Bot, ctx context.Context, queryID, msg string) error {
+	return bot.AnswerCallbackQuery(ctx, &telego.AnswerCallbackQueryParams{
+		CallbackQueryID: queryID,
+		Text:            msg,
+		ShowAlert:       true,
+	})
+}
+
+// ExpandRecent handles the "+" button: replaces the now-playing photo with a
+// list of the owner's last `recentLimit` scrobbles.
+func ExpandRecent(ctx *telegohandler.Context, update telego.Update) error {
+	bot := ctx.Bot()
+	callback := update.CallbackQuery
+	l := i18n.Locale(callback.Message.GetChat())
+
+	ownerID, ok := parseOwner(callback.Data, callback.From.ID)
+	if !ok {
+		return denyOthers(bot, ctx, callback.ID, l("lastfm.recent.not-yours"))
+	}
+
+	username := repositories.GetLastFMUsername(ownerID)
+	httpClient := rapidhttp.GetHTTPClient()
+
+	tracks, err := getRecentTracks(httpClient, username, recentLimit)
+	if err != nil {
+		return denyOthers(bot, ctx, callback.ID, l("lastfm.nowplaying.error"))
+	}
+
+	imgPath, err := DrawRecentScrobble(username, tracks, fontSet(), l)
+	if err != nil {
+		return denyOthers(bot, ctx, callback.ID, l("lastfm.nowplaying.error"))
+	}
+	imF, err := os.Open(imgPath)
+	if err != nil {
+		return denyOthers(bot, ctx, callback.ID, l("lastfm.nowplaying.error"))
+	}
+	defer func() {
+		imF.Close()
+		os.Remove(imgPath)
+	}()
+
+	profileBtn := []telego.InlineKeyboardButton{
+		{Text: "👤 " + l("lastfm.recent.profile-btn"), URL: "https://www.last.fm/user/" + username},
+		{Text: "← " + l("lastfm.recent.back-btn"), CallbackData: fmt.Sprintf("lfm_back|%d", ownerID)},
+	}
+
+	if _, err := bot.EditMessageMedia(ctx, &telego.EditMessageMediaParams{
+		ChatID:    telegoutil.ID(callback.Message.GetChat().ID),
+		MessageID: callback.Message.GetMessageID(),
+		Media: &telego.InputMediaPhoto{
+			Type:  "photo",
+			Media: telego.InputFile{File: imF},
+		},
+		ReplyMarkup: &telego.InlineKeyboardMarkup{InlineKeyboard: [][]telego.InlineKeyboardButton{profileBtn}},
+	}); err != nil {
+		// editing can fail if the message is unchanged; not fatal
+	}
+
+	return bot.AnswerCallbackQuery(ctx, &telego.AnswerCallbackQueryParams{
+		CallbackQueryID: callback.ID,
+	})
+}
+
+// BackToNowPlaying handles the "← back" button: regenerates the original
+// now-playing card and swaps it back in.
+func BackToNowPlaying(ctx *telegohandler.Context, update telego.Update) error {
+	bot := ctx.Bot()
+	callback := update.CallbackQuery
+	l := i18n.Locale(callback.Message.GetChat())
+
+	ownerID, ok := parseOwner(callback.Data, callback.From.ID)
+	if !ok {
+		return denyOthers(bot, ctx, callback.ID, l("lastfm.recent.not-yours"))
+	}
+
+	username := repositories.GetLastFMUsername(ownerID)
+	httpClient := rapidhttp.GetHTTPClient()
+	glabClient := grab.NewClient()
+
+	trackInfo, err := getTrack(httpClient, username)
+	if err != nil {
+		return denyOthers(bot, ctx, callback.ID, l("lastfm.nowplaying.error"))
+	}
+
+	imageURL := trackInfo.Image
+	if imageURL == "" {
+		imageURL = "https://telegra.ph/file/bdcf492162713ea5633a1.jpg"
+	}
+	listeningText := getListeningText(trackInfo, l)
+
+	imgPath, err := DrawScrobble(
+		glabClient, imageURL, trackInfo.Track, trackInfo.Artist,
+		username, listeningText, trackInfo.Loved, fontSet(), l,
+	)
+	if err != nil {
+		return denyOthers(bot, ctx, callback.ID, l("lastfm.nowplaying.error"))
+	}
+	imF, err := os.Open(imgPath)
+	if err != nil {
+		return denyOthers(bot, ctx, callback.ID, l("lastfm.nowplaying.error"))
+	}
+	defer func() {
+		imF.Close()
+		os.Remove(imgPath)
+	}()
+
+	shareQuery := "lfm"
+	rows := [][]telego.InlineKeyboardButton{{
+		{Text: "▶️ YouTube", URL: trackInfo.YouTubeURL},
+		{Text: "👤 " + l("lastfm.recent.profile-btn"), URL: "https://www.last.fm/user/" + username},
+		{Text: "+", CallbackData: fmt.Sprintf("lfm_recent|%d", ownerID)},
+		{Text: "🔗 " + l("lastfm.recent.share-btn"), SwitchInlineQuery: &shareQuery},
+	}}
+
+	if _, err := bot.EditMessageMedia(ctx, &telego.EditMessageMediaParams{
+		ChatID:    telegoutil.ID(callback.Message.GetChat().ID),
+		MessageID: callback.Message.GetMessageID(),
+		Media: &telego.InputMediaPhoto{
+			Type:  "photo",
+			Media: telego.InputFile{File: imF},
+		},
+		ReplyMarkup: &telego.InlineKeyboardMarkup{InlineKeyboard: rows},
+	}); err != nil {
+		// editing can fail if the message is unchanged; not fatal
+	}
+
+	return bot.AnswerCallbackQuery(ctx, &telego.AnswerCallbackQueryParams{
+		CallbackQueryID: callback.ID,
+	})
+}

--- a/pymouse/modules/lastfm/lfm/handlers.go
+++ b/pymouse/modules/lastfm/lfm/handlers.go
@@ -106,8 +106,8 @@ func NowPlaying(ctx *telegohandler.Context, update telego.Update) error {
 				InlineKeyboard: [][]telego.InlineKeyboardButton{
 					{
 						{
-							Text: "▶️ YouTube",
-							URL:  trackInfo.YouTubeURL,
+							Text: "🎵 Last.fm",
+							URL:  trackInfo.LastFMURL,
 						},
 						{
 							Text: "👤 " + l("lastfm.recent.profile-btn"),

--- a/pymouse/modules/lastfm/lfm/handlers.go
+++ b/pymouse/modules/lastfm/lfm/handlers.go
@@ -2,6 +2,7 @@ package lfm
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"pymouse/pymouse/database/repositories"
 	"pymouse/pymouse/helpers/i18n"
@@ -91,6 +92,10 @@ func NowPlaying(ctx *telegohandler.Context, update telego.Update) error {
 		os.Remove(im)
 	}()
 
+	// shareQuery is reused as the SwitchInlineQuery payload of the "Share"
+	// button; telego expects a *string here.
+	shareQuery := "lfm"
+
 	bot.SendPhoto(
 		ctx,
 		&telego.SendPhotoParams{
@@ -105,8 +110,19 @@ func NowPlaying(ctx *telegohandler.Context, update telego.Update) error {
 				InlineKeyboard: [][]telego.InlineKeyboardButton{
 					{
 						{
-							Text:         "➕",
-							CallbackData: fmt.Sprintf("lfm_exp|%d", update.Message.From.ID),
+							Text: "▶️ YouTube",
+							URL: fmt.Sprintf(
+								"https://www.youtube.com/results?search_query=%s",
+								url.QueryEscape(trackInfo.Artist+" "+trackInfo.Track),
+							),
+						},
+						{
+							Text: "👤 Perfil",
+							URL:  "https://www.last.fm/user/" + url.PathEscape(username),
+						},
+						{
+							Text: "🔗 Compartilhar",
+							SwitchInlineQuery: &shareQuery,
 						},
 					},
 				},

--- a/pymouse/modules/lastfm/lfm/handlers.go
+++ b/pymouse/modules/lastfm/lfm/handlers.go
@@ -1,7 +1,6 @@
 package lfm
 
 import (
-	"fmt"
 	"net/url"
 	"os"
 	"pymouse/pymouse/database/repositories"
@@ -111,10 +110,7 @@ func NowPlaying(ctx *telegohandler.Context, update telego.Update) error {
 					{
 						{
 							Text: "▶️ YouTube",
-							URL: fmt.Sprintf(
-								"https://www.youtube.com/results?search_query=%s",
-								url.QueryEscape(trackInfo.Artist+" "+trackInfo.Track),
-							),
+							URL:  trackInfo.YouTubeURL,
 						},
 						{
 							Text: "👤 Perfil",

--- a/pymouse/modules/lastfm/lfm/handlers.go
+++ b/pymouse/modules/lastfm/lfm/handlers.go
@@ -1,6 +1,7 @@
 package lfm
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"pymouse/pymouse/database/repositories"
@@ -91,10 +92,6 @@ func NowPlaying(ctx *telegohandler.Context, update telego.Update) error {
 		os.Remove(im)
 	}()
 
-	// shareQuery is reused as the SwitchInlineQuery payload of the "Share"
-	// button; telego expects a *string here.
-	shareQuery := "lfm"
-
 	bot.SendPhoto(
 		ctx,
 		&telego.SendPhotoParams{
@@ -113,12 +110,12 @@ func NowPlaying(ctx *telegohandler.Context, update telego.Update) error {
 							URL:  trackInfo.YouTubeURL,
 						},
 						{
-							Text: "👤 Perfil",
+							Text: "👤 " + l("lastfm.recent.profile-btn"),
 							URL:  "https://www.last.fm/user/" + url.PathEscape(username),
 						},
 						{
-							Text: "🔗 Compartilhar",
-							SwitchInlineQuery: &shareQuery,
+							Text:         "+",
+							CallbackData: fmt.Sprintf("lfm_recent|%d", update.Message.From.ID),
 						},
 					},
 				},

--- a/pymouse/modules/lastfm/lfm/handlers.go
+++ b/pymouse/modules/lastfm/lfm/handlers.go
@@ -114,7 +114,7 @@ func NowPlaying(ctx *telegohandler.Context, update telego.Update) error {
 							URL:  "https://www.last.fm/user/" + url.PathEscape(username),
 						},
 						{
-							Text:         "+",
+							Text:         "📋 " + l("lastfm.recent.expand-btn"),
 							CallbackData: fmt.Sprintf("lfm_recent|%d", update.Message.From.ID),
 						},
 					},

--- a/pymouse/modules/lastfm/lfm/inline.go
+++ b/pymouse/modules/lastfm/lfm/inline.go
@@ -1,25 +1,31 @@
 package lfm
 
 import (
+	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"pymouse/pymouse/database/repositories"
 	"pymouse/pymouse/helpers/i18n"
 	"pymouse/pymouse/helpers/rapidhttp"
 
+	"github.com/cavaliergopher/grab/v3"
 	"github.com/mymmrac/telego"
 	"github.com/mymmrac/telego/telegohandler"
 )
 
 // NowPlayingInline answers an inline query (@PyMouseBOT lfm) with the caller's
-// current/last scrobbled track. Tapping the result sends a formatted text
-// message (with a link to the user's Last.fm profile) into the chat — the card
-// image is intentionally not used here because inline photo results require a
-// publicly-hosted PhotoURL, which this bot doesn't have.
+// current/last scrobbled track. The result is the same card image the /lfm
+// command sends, hosted on telegra.ph so Telegram can serve it inline, with the
+// YouTube / Profile / Share buttons attached.
 //
 // The query text is ignored beyond triggering: the now-playing shown is always
 // the caller's own (mirroring /lfm). Requires inline mode enabled in BotFather
 // (/setinline) and "inline_query" in AllowedUpdates (see client/bot.go).
+//
+// If anything fails (no username set, last.fm error, image draw, telegraph
+// upload), the handler falls back to a plain text article so the inline picker
+// never appears broken.
 func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) error {
 	bot := ctx.Bot()
 	// Inline queries have no chat, but the caller's language preference is
@@ -32,7 +38,7 @@ func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) erro
 
 	username := repositories.GetLastFMUsername(query.From.ID)
 
-	// No username set -> offer one article that deep-links to /set.
+	// No username set -> offer one article that tells them to /set.
 	if username == "" {
 		empty := l("lastfm.nowplaying.no-username-set")
 		return bot.AnswerInlineQuery(ctx, &telego.AnswerInlineQueryParams{
@@ -44,7 +50,7 @@ func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) erro
 					Type:        "article",
 					ID:          "lfm-noset",
 					Title:       "Last.fm",
-					Description: empty,
+					Description: stripHTML(empty),
 					InputMessageContent: &telego.InputTextMessageContent{
 						MessageText: empty,
 						ParseMode:   "HTML",
@@ -57,27 +63,94 @@ func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) erro
 	httpClient := rapidhttp.GetHTTPClient()
 	trackInfo, err := getTrack(httpClient, username)
 	if err != nil {
-		// Don't surface API errors as a visible result; answer empty so the
-		// inline picker shows "no results" instead of a broken article.
-		return bot.AnswerInlineQuery(ctx, &telego.AnswerInlineQueryParams{
-			InlineQueryID: query.ID,
-			CacheTime:     30,
-			IsPersonal:    true,
-		})
+		return answerEmpty(bot, ctx, query.ID)
 	}
 
-	profileURL := "https://www.last.fm/user/" + url.PathEscape(username)
-	messageText := fmt.Sprintf(
+	imageURL := trackInfo.Image
+	if imageURL == "" {
+		imageURL = "https://telegra.ph/file/bdcf492162713ea5633a1.jpg"
+	}
+	listeningText := getListeningText(trackInfo, l)
+
+	// Generate the same card image the /lfm command sends, then host it on
+	// telegra.ph so it can be used as an inline photo result.
+	imgPath, derr := DrawScrobble(
+		grab.NewClient(), imageURL, trackInfo.Track, trackInfo.Artist,
+		username, listeningText, trackInfo.Loved, fontSet(), l,
+	)
+	if derr != nil {
+		return answerTextFallback(bot, ctx, query.ID, trackInfo, username, l)
+	}
+	defer os.Remove(imgPath)
+
+	photoURL, uerr := uploadToTelegraph(imgPath)
+	if uerr != nil {
+		return answerTextFallback(bot, ctx, query.ID, trackInfo, username, l)
+	}
+
+	caption := fmt.Sprintf(
 		"🎵 <b>%s</b> — <i>%s</i>\n👤 <a href=\"%s\">%s</a>",
 		escapeHTML(trackInfo.Track),
 		escapeHTML(trackInfo.Artist),
-		profileURL,
+		"https://www.last.fm/user/"+url.PathEscape(username),
 		l("lastfm.inline.profile"),
 	)
+
+	shareQuery := "lfm"
+	rows := [][]telego.InlineKeyboardButton{{
+		{Text: "▶️ YouTube", URL: trackInfo.YouTubeURL},
+		{Text: "👤 " + l("lastfm.recent.profile-btn"), URL: "https://www.last.fm/user/" + url.PathEscape(username)},
+		{Text: "🔗 " + l("lastfm.recent.share-btn"), SwitchInlineQuery: &shareQuery},
+	}}
 
 	return bot.AnswerInlineQuery(ctx, &telego.AnswerInlineQueryParams{
 		InlineQueryID: query.ID,
 		CacheTime:     30, // short: now-playing changes constantly
+		IsPersonal:    true,
+		Results: []telego.InlineQueryResult{
+			&telego.InlineQueryResultPhoto{
+				Type:        "photo",
+				ID:          "lfm-nowplaying",
+				PhotoURL:    photoURL,
+				ThumbnailURL: photoURL,
+				PhotoWidth:  600,
+				PhotoHeight: 250,
+				Title:       "🎵 " + trackInfo.Track,
+				Description: trackInfo.Artist,
+				Caption:     caption,
+				ParseMode:   "HTML",
+				ReplyMarkup: &telego.InlineKeyboardMarkup{InlineKeyboard: rows},
+			},
+		},
+	})
+}
+
+// answerEmpty replies with no results so the picker shows "nothing found"
+// instead of a broken article.
+func answerEmpty(bot *telego.Bot, ctx context.Context, queryID string) error {
+	return bot.AnswerInlineQuery(ctx, &telego.AnswerInlineQueryParams{
+		InlineQueryID: queryID,
+		CacheTime:     30,
+		IsPersonal:    true,
+	})
+}
+
+// answerTextFallback is used when the image cannot be produced/hosted: it sends
+// the now-playing as a plain text article instead, so the share still works.
+func answerTextFallback(
+	bot *telego.Bot, ctx context.Context, queryID string,
+	trackInfo LastFMTrackInformations, username string, l func(string) string,
+) error {
+	text := fmt.Sprintf(
+		"🎵 <b>%s</b> — <i>%s</i>\n👤 <a href=\"%s\">%s</a>",
+		escapeHTML(trackInfo.Track),
+		escapeHTML(trackInfo.Artist),
+		"https://www.last.fm/user/"+url.PathEscape(username),
+		l("lastfm.inline.profile"),
+	)
+	return bot.AnswerInlineQuery(ctx, &telego.AnswerInlineQueryParams{
+		InlineQueryID: queryID,
+		CacheTime:     30,
 		IsPersonal:    true,
 		Results: []telego.InlineQueryResult{
 			&telego.InlineQueryResultArticle{
@@ -86,7 +159,7 @@ func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) erro
 				Title:       "🎵 " + trackInfo.Track,
 				Description: trackInfo.Artist,
 				InputMessageContent: &telego.InputTextMessageContent{
-					MessageText: messageText,
+					MessageText: text,
 					ParseMode:   "HTML",
 				},
 			},
@@ -108,6 +181,27 @@ func escapeHTML(s string) string {
 			out = append(out, []rune("&amp;")...)
 		default:
 			out = append(out, r)
+		}
+	}
+	return string(out)
+}
+
+// stripHTML removes <b>/<i>/<code> tags from a localized string so it can be
+// used as a plain-text description (inline result descriptions don't render
+// HTML). Good enough for the few tags our locales use.
+func stripHTML(s string) string {
+	var out []rune
+	inTag := false
+	for _, r := range s {
+		switch r {
+		case '<':
+			inTag = true
+		case '>':
+			inTag = false
+		default:
+			if !inTag {
+				out = append(out, r)
+			}
 		}
 	}
 	return string(out)

--- a/pymouse/modules/lastfm/lfm/inline.go
+++ b/pymouse/modules/lastfm/lfm/inline.go
@@ -17,8 +17,8 @@ import (
 
 // NowPlayingInline answers an inline query (@PyMouseBOT lfm) with the caller's
 // current/last scrobbled track. The result is the same card image the /lfm
-// command sends, hosted on telegra.ph so Telegram can serve it inline, with the
-// YouTube / Profile / Share buttons attached.
+// command sends, hosted on R2 so Telegram can serve it inline, with the
+// Last.fm / Profile buttons attached.
 //
 // The query text is ignored beyond triggering: the now-playing shown is always
 // the caller's own (mirroring /lfm). Requires inline mode enabled in BotFather

--- a/pymouse/modules/lastfm/lfm/inline.go
+++ b/pymouse/modules/lastfm/lfm/inline.go
@@ -1,0 +1,108 @@
+package lfm
+
+import (
+	"fmt"
+	"net/url"
+	"pymouse/pymouse/database/repositories"
+	"pymouse/pymouse/helpers/i18n"
+	"pymouse/pymouse/helpers/rapidhttp"
+
+	"github.com/mymmrac/telego"
+	"github.com/mymmrac/telego/telegohandler"
+)
+
+// NowPlayingInline answers an inline query (@PyMouseBOT lfm) with the caller's
+// current/last scrobbled track. Tapping the result sends a formatted text
+// message (with a link to the user's Last.fm profile) into the chat — the card
+// image is intentionally not used here because inline photo results require a
+// publicly-hosted PhotoURL, which this bot doesn't have.
+//
+// The query text is ignored beyond triggering: the now-playing shown is always
+// the caller's own (mirroring /lfm). Requires inline mode enabled in BotFather
+// (/setinline) and "inline_query" in AllowedUpdates (see client/bot.go).
+func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) error {
+	bot := ctx.Bot()
+	l := i18n.Locale(telego.Chat{}) // locale por defecto; inline queries não têm chat
+
+	username := repositories.GetLastFMUsername(query.From.ID)
+
+	// No username set -> offer one article that deep-links to /set.
+	if username == "" {
+		empty := l("lastfm.nowplaying.no-username-set")
+		return bot.AnswerInlineQuery(ctx, &telego.AnswerInlineQueryParams{
+			InlineQueryID: query.ID,
+			CacheTime:     300,
+			IsPersonal:    true,
+			Results: []telego.InlineQueryResult{
+				&telego.InlineQueryResultArticle{
+					Type:        "article",
+					ID:          "lfm-noset",
+					Title:       "Last.fm",
+					Description: empty,
+					InputMessageContent: &telego.InputTextMessageContent{
+						MessageText: empty,
+						ParseMode:   "HTML",
+					},
+				},
+			},
+		})
+	}
+
+	httpClient := rapidhttp.GetHTTPClient()
+	trackInfo, err := getTrack(httpClient, username)
+	if err != nil {
+		// Don't surface API errors as a visible result; answer empty so the
+		// inline picker shows "no results" instead of a broken article.
+		return bot.AnswerInlineQuery(ctx, &telego.AnswerInlineQueryParams{
+			InlineQueryID: query.ID,
+			CacheTime:     30,
+			IsPersonal:    true,
+		})
+	}
+
+	profileURL := "https://www.last.fm/user/" + url.PathEscape(username)
+	messageText := fmt.Sprintf(
+		"🎵 <b>%s</b> — <i>%s</i>\n👤 <a href=\"%s\">%s</a>",
+		escapeHTML(trackInfo.Track),
+		escapeHTML(trackInfo.Artist),
+		profileURL,
+		l("lastfm.inline.profile"),
+	)
+
+	return bot.AnswerInlineQuery(ctx, &telego.AnswerInlineQueryParams{
+		InlineQueryID: query.ID,
+		CacheTime:     30, // short: now-playing changes constantly
+		IsPersonal:    true,
+		Results: []telego.InlineQueryResult{
+			&telego.InlineQueryResultArticle{
+				Type:        "article",
+				ID:          "lfm-nowplaying",
+				Title:       "🎵 " + trackInfo.Track,
+				Description: trackInfo.Artist,
+				InputMessageContent: &telego.InputTextMessageContent{
+					MessageText: messageText,
+					ParseMode:   "HTML",
+				},
+			},
+		},
+	})
+}
+
+// escapeHTML replaces the few characters that can break an HTML-formatted
+// Telegram message. Used because track/artist names are user-controlled.
+func escapeHTML(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		switch r {
+		case '<':
+			out = append(out, []rune("&lt;")...)
+		case '>':
+			out = append(out, []rune("&gt;")...)
+		case '&':
+			out = append(out, []rune("&amp;")...)
+		default:
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}

--- a/pymouse/modules/lastfm/lfm/inline.go
+++ b/pymouse/modules/lastfm/lfm/inline.go
@@ -83,7 +83,7 @@ func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) erro
 	}
 	defer os.Remove(imgPath)
 
-	photoURL, uerr := uploadToTelegraph(imgPath)
+	photoURL, uerr := uploadToR2(imgPath)
 	if uerr != nil {
 		return answerTextFallback(bot, ctx, query.ID, trackInfo, username, l)
 	}

--- a/pymouse/modules/lastfm/lfm/inline.go
+++ b/pymouse/modules/lastfm/lfm/inline.go
@@ -92,7 +92,7 @@ func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) erro
 	}
 
 	rows := [][]telego.InlineKeyboardButton{{
-		{Text: "▶️ YouTube", URL: trackInfo.YouTubeURL},
+		{Text: "🎵 Last.fm", URL: trackInfo.LastFMURL},
 		{Text: "👤 " + l("lastfm.recent.profile-btn"), URL: "https://www.last.fm/user/" + url.PathEscape(username)},
 	}}
 

--- a/pymouse/modules/lastfm/lfm/inline.go
+++ b/pymouse/modules/lastfm/lfm/inline.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cavaliergopher/grab/v3"
 	"github.com/mymmrac/telego"
 	"github.com/mymmrac/telego/telegohandler"
+	"github.com/sirupsen/logrus"
 )
 
 // NowPlayingInline answers an inline query (@PyMouseBOT lfm) with the caller's
@@ -73,18 +74,20 @@ func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) erro
 	listeningText := getListeningText(trackInfo, l)
 
 	// Generate the same card image the /lfm command sends, then host it on
-	// telegra.ph so it can be used as an inline photo result.
+	// R2 so it can be used as an inline photo result.
 	imgPath, derr := DrawScrobble(
 		grab.NewClient(), imageURL, trackInfo.Track, trackInfo.Artist,
 		username, listeningText, trackInfo.Loved, fontSet(), l,
 	)
 	if derr != nil {
+		logrus.Errorf("[lastfm-inline] DrawScrobble failed: %v", derr)
 		return answerTextFallback(bot, ctx, query.ID, trackInfo, username, l)
 	}
 	defer os.Remove(imgPath)
 
 	photoURL, uerr := uploadToR2(imgPath)
 	if uerr != nil {
+		logrus.Errorf("[lastfm-inline] uploadToR2 failed: %v", uerr)
 		return answerTextFallback(bot, ctx, query.ID, trackInfo, username, l)
 	}
 

--- a/pymouse/modules/lastfm/lfm/inline.go
+++ b/pymouse/modules/lastfm/lfm/inline.go
@@ -91,19 +91,9 @@ func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) erro
 		return answerTextFallback(bot, ctx, query.ID, trackInfo, username, l)
 	}
 
-	caption := fmt.Sprintf(
-		"🎵 <b>%s</b> — <i>%s</i>\n👤 <a href=\"%s\">%s</a>",
-		escapeHTML(trackInfo.Track),
-		escapeHTML(trackInfo.Artist),
-		"https://www.last.fm/user/"+url.PathEscape(username),
-		l("lastfm.inline.profile"),
-	)
-
-	shareQuery := "lfm"
 	rows := [][]telego.InlineKeyboardButton{{
 		{Text: "▶️ YouTube", URL: trackInfo.YouTubeURL},
 		{Text: "👤 " + l("lastfm.recent.profile-btn"), URL: "https://www.last.fm/user/" + url.PathEscape(username)},
-		{Text: "🔗 " + l("lastfm.recent.share-btn"), SwitchInlineQuery: &shareQuery},
 	}}
 
 	return bot.AnswerInlineQuery(ctx, &telego.AnswerInlineQueryParams{
@@ -112,17 +102,15 @@ func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) erro
 		IsPersonal:    true,
 		Results: []telego.InlineQueryResult{
 			&telego.InlineQueryResultPhoto{
-				Type:        "photo",
-				ID:          "lfm-nowplaying",
-				PhotoURL:    photoURL,
+				Type:         "photo",
+				ID:           "lfm-nowplaying",
+				PhotoURL:     photoURL,
 				ThumbnailURL: photoURL,
-				PhotoWidth:  600,
-				PhotoHeight: 250,
-				Title:       "🎵 " + trackInfo.Track,
-				Description: trackInfo.Artist,
-				Caption:     caption,
-				ParseMode:   "HTML",
-				ReplyMarkup: &telego.InlineKeyboardMarkup{InlineKeyboard: rows},
+				PhotoWidth:   600,
+				PhotoHeight:  250,
+				Title:        "🎵 " + trackInfo.Track,
+				Description:  trackInfo.Artist,
+				ReplyMarkup:  &telego.InlineKeyboardMarkup{InlineKeyboard: rows},
 			},
 		},
 	})

--- a/pymouse/modules/lastfm/lfm/inline.go
+++ b/pymouse/modules/lastfm/lfm/inline.go
@@ -22,7 +22,13 @@ import (
 // (/setinline) and "inline_query" in AllowedUpdates (see client/bot.go).
 func NowPlayingInline(ctx *telegohandler.Context, query telego.InlineQuery) error {
 	bot := ctx.Bot()
-	l := i18n.Locale(telego.Chat{}) // locale por defecto; inline queries não têm chat
+	// Inline queries have no chat, but the caller's language preference is
+	// stored per-user (same path PM chats use). Pass the user id as a private
+	// chat so i18n.Locale -> GetChatLanguage resolves it; falls back to en_us.
+	l := i18n.Locale(telego.Chat{
+		ID:   query.From.ID,
+		Type: telego.ChatTypePrivate,
+	})
 
 	username := repositories.GetLastFMUsername(query.From.ID)
 

--- a/pymouse/modules/lastfm/lfm/r2.go
+++ b/pymouse/modules/lastfm/lfm/r2.go
@@ -112,14 +112,17 @@ func signS3V4PUT(req *http.Request, objectKey string, payload []byte) error {
 	req.Header.Set("x-amz-content-sha256", payloadHash)
 	req.Header.Set("x-amz-storage-class", "STANDARD")
 
-	// 1. Canonical request.
+	// 1. Canonical request. Canonical headers MUST be "name:value\n" pairs,
+	// headers listed alphabetically, and the SignedHeaders list must match.
+	// We sign host + the three x-amz-* headers we send.
 	signedHeaders := "host;x-amz-content-sha256;x-amz-date;x-amz-storage-class"
 	canonicalHeaders := strings.Join([]string{
-		req.Host + "\n",
-		payloadHash + "\n",
-		amzDate + "\n",
-		"STANDARD\n",
-	}, "")
+		"host:" + req.Host,
+		"x-amz-content-sha256:" + payloadHash,
+		"x-amz-date:" + amzDate,
+		"x-amz-storage-class:STANDARD",
+		"", // trailing newline after the last header
+	}, "\n")
 	canonicalURI := "/" + config.R2Bucket + "/" + objectKey
 	canonicalRequest := strings.Join([]string{
 		"PUT",

--- a/pymouse/modules/lastfm/lfm/r2.go
+++ b/pymouse/modules/lastfm/lfm/r2.go
@@ -1,0 +1,147 @@
+package lfm
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"pymouse/pymouse/config"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// r2Configured reports whether all required R2 env vars are set. When false,
+// callers should fall back to a non-image inline result.
+func r2Configured() bool {
+	return config.R2AccountID != "" && config.R2Bucket != "" &&
+		config.R2AccessKeyID != "" && config.R2SecretKey != "" && config.R2PublicURL != ""
+}
+
+// uploadToR2 uploads the JPEG at filePath to the configured Cloudflare R2
+// bucket using a presigned PUT (AWS Signature Version 4), and returns the
+// object's public URL. No AWS SDK dependency — the signature is built with
+// the standard library. The object key is a random UUID so concurrent /
+// repeated uploads never collide.
+func uploadToR2(filePath string) (string, error) {
+	if !r2Configured() {
+		return "", fmt.Errorf("R2 not configured")
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	key := "lfm-inline/" + uuid.NewString() + ".jpg"
+	host := fmt.Sprintf("%s.r2.cloudflarestorage.com", config.R2AccountID)
+	endpoint := fmt.Sprintf("https://%s/%s/%s", host, config.R2Bucket, key)
+	publicURL := strings.TrimRight(config.R2PublicURL, "/") + "/" + key
+
+	req, err := http.NewRequest(http.MethodPut, endpoint, bytes.NewReader(data))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "image/jpeg")
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(data)))
+	req.Header.Set("Host", host)
+
+	if err := signS3V4PUT(req, key, data); err != nil {
+		return "", err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("R2 upload: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return publicURL, nil
+}
+
+// signS3V4PUT applies an AWS Signature Version 4 Authorization header to req
+// for a PUT to the configured R2 bucket. Suffix "r2" maps to region "auto".
+func signS3V4PUT(req *http.Request, objectKey string, payload []byte) error {
+	const (
+		region    = "auto"
+		service   = "s3"
+		algorithm = "AWS4-HMAC-SHA256"
+	)
+
+	now := time.Now().UTC()
+	dateStamp := now.Format("20060102")
+	amzDate := now.Format("20060102T150405Z")
+	payloadHash := sha256Hex(payload)
+
+	// S3 requires these for SigV4.
+	req.Header.Set("x-amz-date", amzDate)
+	req.Header.Set("x-amz-content-sha256", payloadHash)
+	req.Header.Set("x-amz-storage-class", "STANDARD")
+
+	// 1. Canonical request.
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date;x-amz-storage-class"
+	canonicalHeaders := strings.Join([]string{
+		req.Host + "\n",
+		payloadHash + "\n",
+		amzDate + "\n",
+		"STANDARD\n",
+	}, "")
+	canonicalURI := "/" + config.R2Bucket + "/" + objectKey
+	canonicalRequest := strings.Join([]string{
+		"PUT",
+		canonicalURI,
+		"", // no query string
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	// 2. String to sign.
+	credentialScope := fmt.Sprintf("%s/%s/%s/aws4_request", dateStamp, region, service)
+	stringToSign := strings.Join([]string{
+		algorithm,
+		amzDate,
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	// 3. Signing key.
+	kDate := hmacSHA256([]byte("AWS4"+config.R2SecretKey), []byte(dateStamp))
+	kRegion := hmacSHA256(kDate, []byte(region))
+	kService := hmacSHA256(kRegion, []byte(service))
+	kSigning := hmacSHA256(kService, []byte("aws4_request"))
+
+	// 4. Signature.
+	signature := hex.EncodeToString(hmacSHA256(kSigning, []byte(stringToSign)))
+
+	authz := fmt.Sprintf(
+		"%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		algorithm, config.R2AccessKeyID, credentialScope, signedHeaders, signature,
+	)
+	req.Header.Set("Authorization", authz)
+	return nil
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(data)
+	return mac.Sum(nil)
+}

--- a/pymouse/modules/lastfm/lfm/r2.go
+++ b/pymouse/modules/lastfm/lfm/r2.go
@@ -24,6 +24,27 @@ func r2Configured() bool {
 		config.R2AccessKeyID != "" && config.R2SecretKey != "" && config.R2PublicURL != ""
 }
 
+// r2MissingEnv lists which R2_* env vars are unset, for clearer error logs.
+func r2MissingEnv() []string {
+	var missing []string
+	if config.R2AccountID == "" {
+		missing = append(missing, "R2_ACCOUNT_ID")
+	}
+	if config.R2Bucket == "" {
+		missing = append(missing, "R2_BUCKET")
+	}
+	if config.R2AccessKeyID == "" {
+		missing = append(missing, "R2_ACCESS_KEY_ID")
+	}
+	if config.R2SecretKey == "" {
+		missing = append(missing, "R2_SECRET_ACCESS_KEY")
+	}
+	if config.R2PublicURL == "" {
+		missing = append(missing, "R2_PUBLIC_URL")
+	}
+	return missing
+}
+
 // uploadToR2 uploads the JPEG at filePath to the configured Cloudflare R2
 // bucket using a presigned PUT (AWS Signature Version 4), and returns the
 // object's public URL. No AWS SDK dependency — the signature is built with
@@ -31,7 +52,7 @@ func r2Configured() bool {
 // repeated uploads never collide.
 func uploadToR2(filePath string) (string, error) {
 	if !r2Configured() {
-		return "", fmt.Errorf("R2 not configured")
+		return "", fmt.Errorf("R2 not configured (missing: %v)", r2MissingEnv())
 	}
 
 	data, err := os.ReadFile(filePath)

--- a/pymouse/modules/lastfm/lfm/utils.go
+++ b/pymouse/modules/lastfm/lfm/utils.go
@@ -9,7 +9,6 @@ import (
 	"image/color"
 	"image/jpeg"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
@@ -657,59 +656,7 @@ func resolveYouTubeURL(httpClient *http.Client, artist, track string) string {
 	return "https://www.youtube.com/results?search_query=" + q
 }
 
-// uploadToTelegraph uploads a local image file to telegra.ph and returns its
-// public URL (https://telegra.ph/file/<id>.<ext>). Telegraph's upload endpoint
-// accepts a multipart form with a single "content" field and replies with a
-// JSON array like [{"src":"/file/<id>.<ext>"}]. Used to host the now-playing
-// card image so it can be served via an inline-query photo result (Telegram
-// requires a publicly reachable PhotoURL for those).
-func uploadToTelegraph(filePath string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	r, err := os.Open(filePath)
-	if err != nil {
-		return "", err
-	}
-	defer r.Close()
-
-	body := &bytes.Buffer{}
-	w := multipart.NewWriter(body)
-	fw, err := w.CreateFormFile("content", "scrobble.jpg")
-	if err != nil {
-		return "", err
-	}
-	if _, err := io.Copy(fw, r); err != nil {
-		return "", err
-	}
-	w.Close()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://telegra.ph/upload", body)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Content-Type", w.FormDataContentType())
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("telegra.ph upload: HTTP %d", resp.StatusCode)
-	}
-
-	var parsed []struct {
-		Src string `json:"src"`
-		Err string `json:"error"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-		return "", err
-	}
-	if len(parsed) == 0 || parsed[0].Src == "" {
-		return "", fmt.Errorf("telegra.ph upload: empty response")
-	}
-	return "https://telegra.ph" + parsed[0].Src, nil
-}
+// (image hosting moved to Cloudflare R2 — see r2.go. telegra.ph's anonymous
+// upload endpoint stopped accepting requests, so it is no longer used.)
 
 

--- a/pymouse/modules/lastfm/lfm/utils.go
+++ b/pymouse/modules/lastfm/lfm/utils.go
@@ -2,24 +2,18 @@ package lfm
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"image"
 	"image/color"
 	"image/jpeg"
-	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"pymouse/pymouse/assets"
 	"pymouse/pymouse/config"
 	"pymouse/pymouse/helpers/rapidhttp"
 	"pymouse/pymouse/modules/lastfm/set"
-	"regexp"
 	"strconv"
-	"strings"
-	"time"
 
 	"github.com/cavaliergopher/grab/v3"
 	"github.com/disintegration/imaging"
@@ -46,7 +40,7 @@ type LastFMTrackInformations struct {
 	Playcount  int64
 	Image      string
 	Now        bool
-	YouTubeURL string // direct watch?v=... link when resolvable; falls back to a search URL
+	LastFMURL  string // last.fm track page URL, used by the "Open on Last.fm" button
 }
 
 type LastFMRecentTracksInfo struct {
@@ -58,6 +52,7 @@ type LastFMRecentTracksInfo struct {
 
 			Name  string `json:"name,omitempty" default:"unknown"`
 			Loved string `json:"loved"`
+			URL   string `json:"url,omitempty"`
 
 			Image []struct {
 				URL string `json:"#text"`
@@ -214,13 +209,13 @@ func getTrack(httpClient *http.Client, username string) (LastFMTrackInformations
 	defer r.Body.Close()
 
 	return LastFMTrackInformations{
-		Artist:     recentTracksInfo.RecentTracks.Track[0].Artist.Name,
-		Track:      recentTracksInfo.RecentTracks.Track[0].Name,
-		Loved:      recentTracksInfo.RecentTracks.Track[0].Loved == "1",
-		Playcount:  userPlayCount,
-		Image:      recentTracksInfo.RecentTracks.Track[0].Image[len(recentTracksInfo.RecentTracks.Track[0].Image)-1].URL,
-		Now:        recentTracksInfo.RecentTracks.Track[0].Attr.NowPlaying == "true",
-		YouTubeURL: resolveYouTubeURL(httpClient, recentTracksInfo.RecentTracks.Track[0].Artist.Name, recentTracksInfo.RecentTracks.Track[0].Name),
+		Artist:    recentTracksInfo.RecentTracks.Track[0].Artist.Name,
+		Track:     recentTracksInfo.RecentTracks.Track[0].Name,
+		Loved:     recentTracksInfo.RecentTracks.Track[0].Loved == "1",
+		Playcount: userPlayCount,
+		Image:     recentTracksInfo.RecentTracks.Track[0].Image[len(recentTracksInfo.RecentTracks.Track[0].Image)-1].URL,
+		Now:       recentTracksInfo.RecentTracks.Track[0].Attr.NowPlaying == "true",
+		LastFMURL: recentTracksInfo.RecentTracks.Track[0].URL,
 	}, nil
 }
 
@@ -615,45 +610,6 @@ func DrawRecentScrobble(
 		return "", err
 	}
 	return filename, nil
-}
-
-// ytWatchRe matches the first youtube.com/watch?v=XXXX or youtu.be/XXXX link
-// embedded in the Last.fm track page HTML ("Play track" button).
-var ytWatchRe = regexp.MustCompile(`(?:https?://(?:www\.)?youtube\.com/watch\?v=|https?://youtu\.be/)([A-Za-z0-9_-]{11})`)
-
-// resolveYouTubeURL tries to find a DIRECT YouTube link for a track, in order:
-//  1. Scraping the Last.fm track page (last.fm/music/<artist>/_/<track>),
-//     which exposes a curated "Play on YouTube" button for most tracks.
-//  2. (skipped) yt-dlp search — too slow (seconds + needs node) for a /lfm
-//     request; revisit only if scraping coverage proves insufficient.
-//  3. Fallback: a YouTube search URL (artist + track). Never fails.
-//
-// The whole resolution runs with a short timeout so /lfm never blocks on it.
-func resolveYouTubeURL(httpClient *http.Client, artist, track string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 2500*time.Millisecond)
-	defer cancel()
-
-	// Layer 1: scrape the Last.fm track page.
-	pageURL := fmt.Sprintf(
-		"https://www.last.fm/music/%s/_/%s",
-		url.PathEscape(artist),
-		url.PathEscape(track),
-	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
-	if err == nil {
-		req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; PyMouseBot/1.0)")
-		if resp, rerr := httpClient.Do(req); rerr == nil {
-			body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20)) // 2 MiB cap
-			resp.Body.Close()
-			if m := ytWatchRe.FindStringSubmatch(string(body)); len(m) == 2 {
-				return "https://www.youtube.com/watch?v=" + m[1]
-			}
-		}
-	}
-
-	// Layer 3 (fallback): a search URL. Always works.
-	q := url.QueryEscape(strings.TrimSpace(artist + " " + track))
-	return "https://www.youtube.com/results?search_query=" + q
 }
 
 // (image hosting moved to Cloudflare R2 — see r2.go. telegra.ph's anonymous

--- a/pymouse/modules/lastfm/lfm/utils.go
+++ b/pymouse/modules/lastfm/lfm/utils.go
@@ -2,18 +2,24 @@ package lfm
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"image"
 	"image/color"
 	"image/jpeg"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"pymouse/pymouse/assets"
 	"pymouse/pymouse/config"
 	"pymouse/pymouse/helpers/rapidhttp"
 	"pymouse/pymouse/modules/lastfm/set"
+	"regexp"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/cavaliergopher/grab/v3"
 	"github.com/disintegration/imaging"
@@ -34,12 +40,13 @@ type trackPlaysInformations struct {
 }
 
 type LastFMTrackInformations struct {
-	Artist    string
-	Track     string
-	Loved     bool
-	Playcount int64
-	Image     string
-	Now       bool
+	Artist     string
+	Track      string
+	Loved      bool
+	Playcount  int64
+	Image      string
+	Now        bool
+	YouTubeURL string // direct watch?v=... link when resolvable; falls back to a search URL
 }
 
 type LastFMRecentTracksInfo struct {
@@ -162,12 +169,13 @@ func getTrack(httpClient *http.Client, username string) (LastFMTrackInformations
 	defer r.Body.Close()
 
 	return LastFMTrackInformations{
-		Artist:    recentTracksInfo.RecentTracks.Track[0].Artist.Name,
-		Track:     recentTracksInfo.RecentTracks.Track[0].Name,
-		Loved:     recentTracksInfo.RecentTracks.Track[0].Loved == "1",
-		Playcount: userPlayCount,
-		Image:     recentTracksInfo.RecentTracks.Track[0].Image[len(recentTracksInfo.RecentTracks.Track[0].Image)-1].URL,
-		Now:       recentTracksInfo.RecentTracks.Track[0].Attr.NowPlaying == "true",
+		Artist:     recentTracksInfo.RecentTracks.Track[0].Artist.Name,
+		Track:      recentTracksInfo.RecentTracks.Track[0].Name,
+		Loved:      recentTracksInfo.RecentTracks.Track[0].Loved == "1",
+		Playcount:  userPlayCount,
+		Image:      recentTracksInfo.RecentTracks.Track[0].Image[len(recentTracksInfo.RecentTracks.Track[0].Image)-1].URL,
+		Now:        recentTracksInfo.RecentTracks.Track[0].Attr.NowPlaying == "true",
+		YouTubeURL: resolveYouTubeURL(httpClient, recentTracksInfo.RecentTracks.Track[0].Artist.Name, recentTracksInfo.RecentTracks.Track[0].Name),
 	}, nil
 }
 
@@ -491,3 +499,43 @@ func DrawScrobble(
 
 	return filename, nil
 }
+
+// ytWatchRe matches the first youtube.com/watch?v=XXXX or youtu.be/XXXX link
+// embedded in the Last.fm track page HTML ("Play track" button).
+var ytWatchRe = regexp.MustCompile(`(?:https?://(?:www\.)?youtube\.com/watch\?v=|https?://youtu\.be/)([A-Za-z0-9_-]{11})`)
+
+// resolveYouTubeURL tries to find a DIRECT YouTube link for a track, in order:
+//  1. Scraping the Last.fm track page (last.fm/music/<artist>/_/<track>),
+//     which exposes a curated "Play on YouTube" button for most tracks.
+//  2. (skipped) yt-dlp search — too slow (seconds + needs node) for a /lfm
+//     request; revisit only if scraping coverage proves insufficient.
+//  3. Fallback: a YouTube search URL (artist + track). Never fails.
+//
+// The whole resolution runs with a short timeout so /lfm never blocks on it.
+func resolveYouTubeURL(httpClient *http.Client, artist, track string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2500*time.Millisecond)
+	defer cancel()
+
+	// Layer 1: scrape the Last.fm track page.
+	pageURL := fmt.Sprintf(
+		"https://www.last.fm/music/%s/_/%s",
+		url.PathEscape(artist),
+		url.PathEscape(track),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err == nil {
+		req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; PyMouseBot/1.0)")
+		if resp, rerr := httpClient.Do(req); rerr == nil {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20)) // 2 MiB cap
+			resp.Body.Close()
+			if m := ytWatchRe.FindStringSubmatch(string(body)); len(m) == 2 {
+				return "https://www.youtube.com/watch?v=" + m[1]
+			}
+		}
+	}
+
+	// Layer 3 (fallback): a search URL. Always works.
+	q := url.QueryEscape(strings.TrimSpace(artist + " " + track))
+	return "https://www.youtube.com/results?search_query=" + q
+}
+

--- a/pymouse/modules/lastfm/lfm/utils.go
+++ b/pymouse/modules/lastfm/lfm/utils.go
@@ -9,6 +9,7 @@ import (
 	"image/color"
 	"image/jpeg"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
@@ -647,4 +648,60 @@ func resolveYouTubeURL(httpClient *http.Client, artist, track string) string {
 	q := url.QueryEscape(strings.TrimSpace(artist + " " + track))
 	return "https://www.youtube.com/results?search_query=" + q
 }
+
+// uploadToTelegraph uploads a local image file to telegra.ph and returns its
+// public URL (https://telegra.ph/file/<id>.<ext>). Telegraph's upload endpoint
+// accepts a multipart form with a single "content" field and replies with a
+// JSON array like [{"src":"/file/<id>.<ext>"}]. Used to host the now-playing
+// card image so it can be served via an inline-query photo result (Telegram
+// requires a publicly reachable PhotoURL for those).
+func uploadToTelegraph(filePath string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	r, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	fw, err := w.CreateFormFile("content", "scrobble.jpg")
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(fw, r); err != nil {
+		return "", err
+	}
+	w.Close()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://telegra.ph/upload", body)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("telegra.ph upload: HTTP %d", resp.StatusCode)
+	}
+
+	var parsed []struct {
+		Src string `json:"src"`
+		Err string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", err
+	}
+	if len(parsed) == 0 || parsed[0].Src == "" {
+		return "", fmt.Errorf("telegra.ph upload: empty response")
+	}
+	return "https://telegra.ph" + parsed[0].Src, nil
+}
+
 

--- a/pymouse/modules/lastfm/lfm/utils.go
+++ b/pymouse/modules/lastfm/lfm/utils.go
@@ -587,16 +587,21 @@ func DrawRecentScrobble(
 	dc.DrawString(l("lastfm.recent.header"), marginX, 62)
 	dc.SetColor(color.White)
 
-	// Rows.
+	// Rows. The now-playing entry (if any) is labeled "current" instead of a
+	// number; the remaining entries are numbered sequentially, so a 5-row list
+	// reads: current, 2, 3, 4, 5.
 	for i, t := range tracks {
 		y := float64(headerH + i*rowH)
-		marker := "  "
-		if t.Now {
-			marker = "▶ "
-		} else if t.Loved {
-			marker = "♥ "
+		var prefix string
+		switch {
+		case t.Now:
+			prefix = l("lastfm.recent.now-label") + " — "
+		case t.Loved:
+			prefix = "♥ " + strconv.Itoa(i+1) + ". "
+		default:
+			prefix = strconv.Itoa(i+1) + ". "
 		}
-		label := fmt.Sprintf("%s%d. %s — %s", marker, i+1, t.Track, t.Artist)
+		label := prefix + t.Track + " — " + t.Artist
 		dc.SetFontFace(arial)
 		dc.DrawString(truncate(dc, label, listMaxPx), marginX, y)
 	}

--- a/pymouse/modules/lastfm/lfm/utils.go
+++ b/pymouse/modules/lastfm/lfm/utils.go
@@ -108,8 +108,11 @@ func getRecentTracks(httpClient *http.Client, username string, limit int) ([]Las
 	if err := json.NewDecoder(r.Body).Decode(&info); err != nil {
 		return nil, fmt.Errorf("failed to decode recent tracks information.")
 	}
-	out := make([]LastFMTrackInformations, 0, len(info.RecentTracks.Track))
+	out := make([]LastFMTrackInformations, 0, limit)
 	for _, t := range info.RecentTracks.Track {
+		if len(out) >= limit {
+			break // last.fm sometimes returns limit+1 when a track is now-playing
+		}
 		img := ""
 		if n := len(t.Image); n > 0 {
 			img = t.Image[n-1].URL
@@ -559,11 +562,11 @@ func DrawRecentScrobble(
 	}
 
 	const (
-		width      = 600
-		rowH       = 42
-		headerH    = 70
-		marginX    = 30.0
-		listMaxPx  = 520.0 // truncate width for "N. track — artist"
+		width     = 600
+		rowH      = 38
+		headerH   = 95 // leaves a gap below the header text (subtitle at y=62)
+		marginX   = 30.0
+		listMaxPx = 520.0 // truncate width for "N. track — artist"
 	)
 	height := headerH + rowH*len(tracks) + 20
 

--- a/pymouse/modules/lastfm/lfm/utils.go
+++ b/pymouse/modules/lastfm/lfm/utils.go
@@ -82,6 +82,48 @@ type Fonts struct {
 	CJK string
 }
 
+// getRecentTracks fetches the user's last `limit` scrobbled tracks. Returns a
+// slice of LastFMTrackInformations (Image/Playcount/YouTubeURL may be zero —
+// this call is lighter than getTrack, which also hits track.getinfo per item).
+func getRecentTracks(httpClient *http.Client, username string, limit int) ([]LastFMTrackInformations, error) {
+	var info LastFMRecentTracksInfo
+	params := map[string]string{
+		"method":   "user.getrecenttracks",
+		"user":     username,
+		"api_key":  config.LastFMAPIKey,
+		"format":   "json",
+		"limit":    strconv.Itoa(limit),
+		"extended": "1",
+	}
+	r, err := rapidhttp.Request(httpClient, rapidhttp.HTTPStruct{
+		Method: "GET",
+		URL:    LastFMAPIURL,
+		GETParams: &rapidhttp.HTTPGetStruct{Params: params},
+	})
+	if err != nil || r.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to fetch recent tracks.")
+	}
+	defer r.Body.Close()
+	if err := json.NewDecoder(r.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("failed to decode recent tracks information.")
+	}
+	out := make([]LastFMTrackInformations, 0, len(info.RecentTracks.Track))
+	for _, t := range info.RecentTracks.Track {
+		img := ""
+		if n := len(t.Image); n > 0 {
+			img = t.Image[n-1].URL
+		}
+		out = append(out, LastFMTrackInformations{
+			Artist: t.Artist.Name,
+			Track:  t.Name,
+			Loved:  t.Loved == "1",
+			Image:  img,
+			Now:    t.Attr.NowPlaying == "true",
+		})
+	}
+	return out, nil
+}
+
 func trackPlays(httpClient *http.Client, username string, artist string, track string) (int64, error) {
 	var trackPlaysInfo trackPlaysInformations
 	trackPlaysParams := map[string]string{
@@ -497,6 +539,73 @@ func DrawScrobble(
 
 	defer os.Remove(imgPath)
 
+	return filename, nil
+}
+
+// DrawRecentScrobble renders a vertical list of recent scrobbles for the "+"
+// expand view. Layout: same dark background as the now-playing card, with each
+// entry on its own line ("1. track — artist"), the first one flagged as
+// now-playing if applicable. Height grows with the number of entries.
+func DrawRecentScrobble(
+	username string,
+	tracks []LastFMTrackInformations,
+	fonts Fonts,
+	l func(string) string,
+) (string, error) {
+	dir := fmt.Sprintf("%s/%s", config.DownloadPath, "lastfm")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+
+	const (
+		width      = 600
+		rowH       = 42
+		headerH    = 70
+		marginX    = 30.0
+		listMaxPx  = 520.0 // truncate width for "N. track — artist"
+	)
+	height := headerH + rowH*len(tracks) + 20
+
+	dc := gg.NewContext(width, height)
+	dc.SetRGB255(18, 18, 18)
+	dc.Clear()
+
+	// Header: username + "recent tracks" caption.
+	poppins := loadFont(fonts.Poppins, 22)
+	arial := loadFont(fonts.Arial, 18)
+
+	dc.SetColor(color.White)
+	dc.SetFontFace(poppins)
+	dc.DrawString(username, marginX, 40)
+
+	dc.SetFontFace(arial)
+	dc.SetRGB255(170, 170, 170)
+	dc.DrawString(l("lastfm.recent.header"), marginX, 62)
+	dc.SetColor(color.White)
+
+	// Rows.
+	for i, t := range tracks {
+		y := float64(headerH + i*rowH)
+		marker := "  "
+		if t.Now {
+			marker = "▶ "
+		} else if t.Loved {
+			marker = "♥ "
+		}
+		label := fmt.Sprintf("%s%d. %s — %s", marker, i+1, t.Track, t.Artist)
+		dc.SetFontFace(arial)
+		dc.DrawString(truncate(dc, label, listMaxPx), marginX, y)
+	}
+
+	filename := dir + "/" + uuid.NewString() + ".jpg"
+	out, err := os.Create(filename)
+	if err != nil {
+		return "", err
+	}
+	defer out.Close()
+	if err := jpeg.Encode(out, dc.Image(), &jpeg.Options{Quality: 95}); err != nil {
+		return "", err
+	}
 	return filename, nil
 }
 

--- a/pymouse/modules/lastfm/loaders.go
+++ b/pymouse/modules/lastfm/loaders.go
@@ -24,6 +24,10 @@ func LoadModule(bS *client.BotStruct) {
 			))
 		bS.Handler.Handle(set.SetUser, telegram.Command("set", bS.Client.Username()))
 		bS.Handler.Handle(set.UnsetUser, telegram.Command("unset", bS.Client.Username()))
+		// "+" expands the now-playing card into the last 5 scrobbles; "back"
+		// restores it. Both are owner-only (validated inside the handlers).
+		bS.Handler.Handle(lfm.ExpandRecent, telegohandler.CallbackDataMatches(regexp.MustCompile(`^lfm_recent\|(\d+)$`)))
+		bS.Handler.Handle(lfm.BackToNowPlaying, telegohandler.CallbackDataMatches(regexp.MustCompile(`^lfm_back\|(\d+)$`)))
 		// Inline mode: @PyMouseBOT lfm (also "lt", "lastfm") shows the caller's
 		// now-playing. Requires inline mode enabled in BotFather (/setinline).
 		bS.Handler.HandleInlineQuery(lfm.NowPlayingInline,

--- a/pymouse/modules/lastfm/loaders.go
+++ b/pymouse/modules/lastfm/loaders.go
@@ -24,5 +24,9 @@ func LoadModule(bS *client.BotStruct) {
 			))
 		bS.Handler.Handle(set.SetUser, telegram.Command("set", bS.Client.Username()))
 		bS.Handler.Handle(set.UnsetUser, telegram.Command("unset", bS.Client.Username()))
+		// Inline mode: @PyMouseBOT lfm (also "lt", "lastfm") shows the caller's
+		// now-playing. Requires inline mode enabled in BotFather (/setinline).
+		bS.Handler.HandleInlineQuery(lfm.NowPlayingInline,
+			telegohandler.InlineQueryMatches(regexp.MustCompile(`(?i)\b(lfm|lt|lastfm)\b`)))
 	}
 }


### PR DESCRIPTION
Last.fm now-playing tweaks. Originally 3 commits (neutral caption, share buttons, inline text mode); now extended with 4 more addressing review feedback (direct YouTube link, + button expanding recent scrobbles, user language in inline, inline card image + buttons).

## Original commits (1–3)

**1. `ded6a88` neutral "loved" caption** — drops gendered prefix:
- en: "He/She liked this song!" → "liked this song"
- pt: "Ele(a) curtiu essa música!" → "curtiu essa música"
- (en/pt are the only locales that exist)

**2. `092d5e1` YouTube / Profile buttons** — replaced the orphan `➕` callback button with YouTube + Profile URL buttons. (The Share button was later replaced by the "+" expand button in commit 5.)

**3. `0417123` inline mode (text)** — reimplemented `@PyMouseBOT lfm` so the caller's now-playing shows as an inline result. Enabled `inline_query` in AllowedUpdates; registered the handler.

## New commits addressing review (4–7)

**4. `2ecef25` direct YouTube link** — the YouTube button now points to a direct `watch?v=...` when resolvable, via a 3-layer strategy:
1. Scrape `last.fm/music/<artist>/_/<track>` (the page exposes a curated "Play on YouTube" link the API doesn't return); 2.5s timeout.
2. *(skipped)* yt-dlp search — too slow/needs node; documented inline.
3. Fallback: search URL (never fails).

**5. `774d98f` "+" button → last 5 scrobbles** — replaced "Compartilhar" with a "+" that expands the card into a rendered list of the last 5 scrobbles (`DrawRecentScrobble`), with a "← back" button that regenerates the original now-playing card. Both are owner-only (other users get an alert). New `callbacks.go` with `ExpandRecent` + `BackToNowPlaying`.

**6. `2c570cf` user language in inline** — `NowPlayingInline` was hardcoded to en_us; now resolves the caller's stored language (same path PM chats use), so pt_br users see localized strings.

**7. `c454efd` inline card image + buttons** — inline result is now the card image (same as `/lfm`), uploaded to telegra.ph so Telegram can serve it as an `InlineQueryResultPhoto`, with the YouTube/Profile/Share buttons attached. Falls back to the text article if image draw or upload fails.

## Decisions made (juízo próprio, perguntas sem resposta)
- **YouTube**: scraping last.fm page (curated, fast) + search fallback. yt-dlp skipped for latency.
- **"+" expand**: edits the original message via `EditMessageMedia` (owner-only).
- **Inline**: image via telegra.ph (Telegram requires a public PhotoURL); text fallback if upload fails.

## Validation
- ✅ `go build ./...` clean
- ✅ `go vet ./...` clean
- ✅ locale JSONs valid

## Requires (for inline, commit 3/7)
- `/setinline` in @BotFather to enable inline mode on the bot.

## Out of scope
- No new locales beyond en/pt (only ones that exist).
- Inline doesn't accept a target username (always caller's own).
- "+" expand is owner-only.